### PR TITLE
Implement quick action handlers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,7 +81,7 @@ function AppContent() {
       case 'blockchain':
         return <BlockchainPage />;
       default:
-        return <Dashboard />;
+        return <Dashboard onPageChange={setCurrentPage} />;
     }
   };
 

--- a/src/components/ContractInteractionForm.tsx
+++ b/src/components/ContractInteractionForm.tsx
@@ -28,8 +28,9 @@ export function ContractInteractionForm() {
         const res = await callContract({ address, abi: parsedAbi, method, args: parsedArgs });
         setResult(JSON.stringify(res));
       }
-    } catch (err: any) {
-      setError(err.message || 'Contract call failed');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Contract call failed';
+      setError(message);
     }
     setIsLoading(false);
   };

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,7 @@
 import { useLanguage } from '../contexts/LanguageContext';
 import { useAuth } from '../contexts/AuthContext';
+import { useState } from 'react';
+import { UploadMediaModal } from './UploadMediaModal';
 import { 
   TrendingUp, 
   Users, 
@@ -55,11 +57,36 @@ function getActivityIcon(type: string) {
   }
 }
 
-export function Dashboard() {
+interface DashboardProps {
+  onPageChange: (page: string) => void;
+}
+
+export function Dashboard({ onPageChange }: DashboardProps) {
   const { t } = useLanguage();
   const { user } = useAuth();
+  const [showUploadModal, setShowUploadModal] = useState(false);
+
+  const handleQuickAction = (actionName: string) => {
+    switch (actionName) {
+      case 'Upload Media':
+        setShowUploadModal(true);
+        break;
+      case 'Create Timeline':
+        onPageChange('timeline');
+        break;
+      case 'New Collection':
+        onPageChange('collections');
+        break;
+      case 'Archive Content':
+        onPageChange('archive');
+        break;
+      default:
+        break;
+    }
+  };
 
   return (
+    <>
     <div className="space-y-8">
       {/* Hero Welcome Card */}
       <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-primary-500 via-purple-500 to-orange-400 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 shadow-2xl mb-4">
@@ -153,6 +180,7 @@ export function Dashboard() {
                 return (
                 <button
                   key={action.name}
+                  onClick={() => handleQuickAction(action.name)}
                   className="flex flex-col items-center p-6 rounded-xl border-2 border-dashed border-gray-200 hover:border-primary-300 hover:bg-gradient-to-br hover:from-primary-50 hover:to-purple-50 transition-all duration-300 group hover:shadow-lg"
                 >
                   <div className={`h-14 w-14 rounded-xl bg-gradient-to-br ${gradients[index]} flex items-center justify-center mb-3 group-hover:scale-110 transition-transform duration-300 shadow-lg`}>
@@ -244,6 +272,14 @@ export function Dashboard() {
         </div>
       </div>
     </div>
+    {showUploadModal && (
+      <UploadMediaModal
+        isOpen={showUploadModal}
+        onClose={() => setShowUploadModal(false)}
+        onUpload={(file) => console.log('Uploaded', file.name)}
+      />
+    )}
+    </>
   );
 // Simple calendar mini component for visual effect
 function CalendarMini() {

--- a/src/components/EthereumWallet.tsx
+++ b/src/components/EthereumWallet.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 // Add TypeScript support for window.ethereum
 declare global {
   interface Window {
-    ethereum?: any;
+    ethereum?: ethers.Eip1193Provider;
   }
 }
 import { ethers } from 'ethers';
@@ -27,8 +27,9 @@ export function EthereumWallet() {
       setAddress(accounts[0]);
       const bal = await provider.getBalance(accounts[0]);
       setBalance(ethers.formatEther(bal));
-    } catch (err) {
-      setError('Could not connect wallet.');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Could not connect wallet.';
+      setError(message);
     }
     setIsLoading(false);
   };

--- a/src/components/SendEthForm.tsx
+++ b/src/components/SendEthForm.tsx
@@ -16,8 +16,9 @@ export function SendEthForm() {
     try {
       const tx = await sendEth({ to, amount });
       setTxHash(tx.hash);
-    } catch (err: any) {
-      setError(err.message || 'Transaction failed');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Transaction failed';
+      setError(message);
     }
     setIsLoading(false);
   };

--- a/src/components/pages/APIPage.tsx
+++ b/src/components/pages/APIPage.tsx
@@ -67,7 +67,17 @@ export function APIPage() {
   useAuth();
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [visibleKeys, setVisibleKeys] = useState<string[]>([]);
-  const [apiKeys, setApiKeys] = useState<any[]>([]);
+  interface ApiKey {
+    id: string;
+    name: string;
+    key: string;
+    permissions: string[];
+    lastUsed?: string;
+    created: string;
+    status: string;
+    requests?: number;
+  }
+  const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
@@ -90,8 +100,9 @@ export function APIPage() {
         if (!token) throw new Error('Not authenticated');
         const keys = await fetchApiKeys(token);
         setApiKeys(keys);
-      } catch (e: any) {
-        setError(e.message || 'Failed to load API keys');
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'Failed to load API keys';
+        setError(message);
       } finally {
         setLoading(false);
       }
@@ -106,8 +117,9 @@ export function APIPage() {
       const newKey = await createApiKey(token, name, permissions);
       setApiKeys(prev => [newKey, ...prev]);
       setToast('API key created!');
-    } catch (e: any) {
-      setToast(e.message || 'Failed to create API key');
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'Failed to create API key';
+      setToast(message);
     }
   };
 
@@ -123,8 +135,9 @@ export function APIPage() {
       const updated = await regenerateApiKey(token, id);
       setApiKeys(prev => prev.map(k => k.id === id ? updated : k));
       setToast('API key regenerated!');
-    } catch (e: any) {
-      setToast(e.message || 'Failed to regenerate API key');
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'Failed to regenerate API key';
+      setToast(message);
     }
   };
 
@@ -136,8 +149,9 @@ export function APIPage() {
         await deleteApiKey(token, id);
         setApiKeys(prev => prev.filter(k => k.id !== id));
         setToast('API key revoked!');
-      } catch (e: any) {
-        setToast(e.message || 'Failed to revoke API key');
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'Failed to revoke API key';
+        setToast(message);
       }
     }
   };

--- a/src/components/pages/ArchivePage.tsx
+++ b/src/components/pages/ArchivePage.tsx
@@ -1,27 +1,19 @@
 import React, { useState } from 'react';
 import { 
-  Archive, 
-  Download, 
-  Upload, 
-  Search, 
-  Filter, 
-  Calendar, 
-  Clock, 
-  Shield, 
-  Database,
+  Archive,
+  Download,
+  Search,
+  Filter,
+  Clock,
+  Shield,
   HardDrive,
   FileText,
   Image,
-  Video,
-  Music,
   Folder,
-  CheckCircle,
-  AlertTriangle,
   MoreHorizontal,
   Eye,
   Trash2,
-  RefreshCw,
-  Settings
+  RefreshCw
 } from 'lucide-react';
 
 const mockArchives = [
@@ -78,6 +70,8 @@ export function ArchivePage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [filterStatus, setFilterStatus] = useState('all');
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [name, setName] = useState('');
+  const [type, setType] = useState('collection');
 
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -99,6 +93,7 @@ export function ArchivePage() {
   };
 
   return (
+    <>
     <div className="space-y-6">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
@@ -310,5 +305,60 @@ export function ArchivePage() {
         </div>
       )}
     </div>
+
+    {showCreateModal && (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-md">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">Create Archive</h3>
+          <form
+            className="space-y-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              mockArchives.unshift({
+                id: String(Date.now()),
+                name,
+                type,
+                size: '0 MB',
+                items: 0,
+                created: new Date().toISOString().slice(0, 10),
+                lastBackup: new Date().toISOString().slice(0, 10),
+                status: 'active',
+                retention: '25 years',
+                format: 'ZIP',
+                checksum: 'SHA-256',
+              });
+              setName('');
+              setType('collection');
+              setShowCreateModal(false);
+            }}
+          >
+            <input
+              className="w-full border border-gray-300 rounded-lg px-3 py-2"
+              placeholder="Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <select
+              className="w-full border border-gray-300 rounded-lg px-3 py-2"
+              value={type}
+              onChange={(e) => setType(e.target.value)}
+            >
+              <option value="collection">Collection</option>
+              <option value="documents">Documents</option>
+              <option value="media">Media</option>
+            </select>
+            <div className="flex justify-end space-x-2">
+              <button type="button" onClick={() => setShowCreateModal(false)} className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700">
+                Cancel
+              </button>
+              <button type="submit" className="px-4 py-2 rounded-lg bg-blue-600 text-white">
+                Create
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    )}
+    </>
   );
 }

--- a/src/components/pages/BackupPage.tsx
+++ b/src/components/pages/BackupPage.tsx
@@ -1,20 +1,17 @@
 import React, { useState } from 'react';
 import { 
-  HardDrive, 
-  Cloud, 
-  Download, 
-  Upload, 
-  RefreshCw, 
-  Calendar, 
-  Clock, 
-  CheckCircle, 
-  AlertTriangle,
+  HardDrive,
+  Cloud,
+  Download,
+  RefreshCw,
+  Calendar,
+  Clock,
+  CheckCircle,
   Settings,
   Shield,
   Database,
   Archive,
   Zap,
-  Globe,
   Server,
   Save
 } from 'lucide-react';
@@ -62,8 +59,10 @@ const backupSchedules = [
 ];
 
 export function BackupPage() {
-  const [selectedBackup, setSelectedBackup] = useState<string | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [name, setName] = useState('');
+  const [type, setType] = useState('full');
+  const [location, setLocation] = useState('cloud');
   const [backupSettings, setBackupSettings] = useState({
     autoBackup: true,
     cloudSync: true,
@@ -102,6 +101,7 @@ export function BackupPage() {
   };
 
   return (
+    <>
     <div className="space-y-6">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
@@ -377,5 +377,68 @@ export function BackupPage() {
         </div>
       </div>
     </div>
+
+    {showCreateModal && (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-md">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">Create Backup</h3>
+          <form
+            className="space-y-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              mockBackups.unshift({
+                id: String(Date.now()),
+                name,
+                type,
+                size: '0 MB',
+                created: new Date().toISOString(),
+                status: 'scheduled',
+                location,
+                retention: '30 days',
+                encrypted: true,
+              });
+              setName('');
+              setType('full');
+              setLocation('cloud');
+              setShowCreateModal(false);
+            }}
+          >
+            <input
+              className="w-full border border-gray-300 rounded-lg px-3 py-2"
+              placeholder="Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <select
+              className="w-full border border-gray-300 rounded-lg px-3 py-2"
+              value={type}
+              onChange={(e) => setType(e.target.value)}
+            >
+              <option value="full">Full</option>
+              <option value="incremental">Incremental</option>
+              <option value="selective">Selective</option>
+            </select>
+            <select
+              className="w-full border border-gray-300 rounded-lg px-3 py-2"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+            >
+              <option value="cloud">Cloud</option>
+              <option value="local">Local</option>
+              <option value="remote">Remote</option>
+            </select>
+            <div className="flex justify-end space-x-2">
+              <button type="button" onClick={() => setShowCreateModal(false)} className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700">
+                Cancel
+              </button>
+              <button type="submit" className="px-4 py-2 rounded-lg bg-blue-600 text-white">
+                Create
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    )}
+    </>
   );
 }

--- a/src/components/pages/CollectionsPage.tsx
+++ b/src/components/pages/CollectionsPage.tsx
@@ -10,7 +10,6 @@ import {
   Trash2,
   FolderOpen,
   ImageIcon,
-  Users,
   Lock,
   Globe
 } from 'lucide-react';
@@ -62,6 +61,8 @@ export function CollectionsPage() {
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   const [searchTerm, setSearchTerm] = useState('');
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newDesc, setNewDesc] = useState('');
 
   const filteredCollections = mockCollections.filter(collection =>
     collection.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -70,6 +71,7 @@ export function CollectionsPage() {
   );
 
   return (
+    <>
     <div className="space-y-6">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
@@ -283,5 +285,62 @@ export function CollectionsPage() {
         )}
       </div>
     </div>
+
+    {showCreateModal && (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-md">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">New Collection</h3>
+          <form
+            className="space-y-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              mockCollections.unshift({
+                id: String(Date.now()),
+                name: newName,
+                description: newDesc,
+                assetCount: 0,
+                isPublic: false,
+                createdAt: new Date().toISOString().slice(0, 10),
+                thumbnail: '',
+                tags: [],
+              });
+              setNewName('');
+              setNewDesc('');
+              setShowCreateModal(false);
+            }}
+          >
+            <input
+              className="w-full border border-gray-300 rounded-lg px-3 py-2"
+              placeholder="Name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              required
+            />
+            <textarea
+              className="w-full border border-gray-300 rounded-lg px-3 py-2"
+              placeholder="Description"
+              value={newDesc}
+              onChange={(e) => setNewDesc(e.target.value)}
+            />
+            <div className="flex justify-end space-x-2">
+              <button
+                type="button"
+                onClick={() => setShowCreateModal(false)}
+                className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="px-4 py-2 rounded-lg bg-blue-600 text-white"
+              >
+                Create
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    )}
+    </>
   );
 }

--- a/src/components/pages/ExportPage.tsx
+++ b/src/components/pages/ExportPage.tsx
@@ -6,8 +6,7 @@ import {
   Video, 
   Music, 
   Archive, 
-  Settings, 
-  Calendar, 
+  Settings,
   Clock,
   CheckCircle,
   AlertTriangle,
@@ -124,6 +123,8 @@ export function ExportPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [filterStatus, setFilterStatus] = useState('all');
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [format, setFormat] = useState('zip');
 
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -158,6 +159,7 @@ export function ExportPage() {
   };
 
   return (
+    <>
     <div className="space-y-6">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
@@ -394,5 +396,60 @@ export function ExportPage() {
         </div>
       </div>
     </div>
+
+    {showCreateModal && (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-md">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">Create Export</h3>
+          <form
+            className="space-y-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              mockExports.unshift({
+                id: String(Date.now()),
+                name: newName || 'New Export',
+                format,
+                status: 'processing',
+                created: new Date().toISOString(),
+                size: '0 MB',
+                downloads: 0,
+              });
+              setNewName('');
+              setFormat('zip');
+              setShowCreateModal(false);
+            }}
+          >
+            <input
+              className="w-full border border-gray-300 rounded-lg px-3 py-2"
+              placeholder="Export Name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+            />
+            <select
+              className="w-full border border-gray-300 rounded-lg px-3 py-2"
+              value={format}
+              onChange={(e) => setFormat(e.target.value)}
+            >
+              {exportFormats.map((fmt) => (
+                <option key={fmt.id} value={fmt.id}>{fmt.name}</option>
+              ))}
+            </select>
+            <div className="flex justify-end space-x-2">
+              <button
+                type="button"
+                onClick={() => setShowCreateModal(false)}
+                className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700"
+              >
+                Cancel
+              </button>
+              <button type="submit" className="px-4 py-2 rounded-lg bg-blue-600 text-white">
+                Create
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- wire quick action buttons in `Dashboard` to useful actions
- enable opening the upload modal
- allow dashboard to navigate to other pages

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68786c0e111083249d67f74d354884f8