### PR TITLE
Add minimal ASP.NET backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Vault of Legacy
+
+This project now includes a small ASP.NET Core backend located in the `server` directory.
+
+## Running the backend
+
+```bash
+cd server
+# build the project
+ dotnet build
+# run the API
+ dotnet run
+```
+
+The API provides in-memory endpoints for user authentication, API key management and file uploads which the React frontend can call using the `/api` path.

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -1,0 +1,92 @@
+using BCrypt.Net;
+using Microsoft.AspNetCore.Http;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+        policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod());
+});
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseCors();
+
+var users = new List<User>();
+var apiKeys = new List<ApiKey>();
+var files = new List<UploadedFile>();
+
+app.MapPost("/api/auth/signup", (SignupRequest req) =>
+{
+    if (users.Any(u => u.Email == req.Email))
+        return Results.BadRequest("Email already registered");
+
+    var user = new User(Guid.NewGuid().ToString(), req.Email, req.Name, BCrypt.Net.BCrypt.HashPassword(req.Password));
+    users.Add(user);
+    return Results.Ok(new { user.Id, user.Email, user.Name });
+});
+
+app.MapPost("/api/auth/login", (LoginRequest req) =>
+{
+    var user = users.FirstOrDefault(u => u.Email == req.Email);
+    if (user == null || !BCrypt.Net.BCrypt.Verify(req.Password, user.PasswordHash))
+        return Results.BadRequest("Invalid credentials");
+
+    return Results.Ok(new { user.Id, user.Email, user.Name });
+});
+
+app.MapPost("/api/file/upload", async (HttpRequest http) =>
+{
+    if (!http.HasFormContentType) return Results.BadRequest("Invalid form");
+    var form = await http.ReadFormAsync();
+    var file = form.Files.FirstOrDefault();
+    if (file == null) return Results.BadRequest("No file provided");
+
+    var dir = Path.Combine(app.Environment.ContentRootPath, "UploadedFiles");
+    Directory.CreateDirectory(dir);
+    var filePath = Path.Combine(dir, Guid.NewGuid().ToString() + "_" + file.FileName);
+    using var stream = File.OpenWrite(filePath);
+    await file.CopyToAsync(stream);
+
+    var uploaded = new UploadedFile(filePath, file.FileName);
+    files.Add(uploaded);
+    return Results.Ok(new { uploaded.Path, uploaded.OriginalName });
+});
+
+app.MapGet("/api/file/list", () => files.Select(f => new { f.Path, f.OriginalName }));
+
+app.MapGet("/api/apikey", () => apiKeys);
+
+app.MapPost("/api/apikey", (ApiKeyRequest request) =>
+{
+    var key = new ApiKey(Guid.NewGuid().ToString(), request.Name, request.Permissions);
+    apiKeys.Add(key);
+    return Results.Ok(key);
+});
+
+app.MapDelete("/api/apikey/{id}", (string id) =>
+{
+    var key = apiKeys.FirstOrDefault(k => k.Id == id);
+    if (key == null) return Results.NotFound();
+    apiKeys.Remove(key);
+    return Results.Ok();
+});
+
+app.Run();
+
+record User(string Id, string Email, string Name, string PasswordHash);
+record SignupRequest(string Email, string Password, string Name);
+record LoginRequest(string Email, string Password);
+record ApiKey(string Id, string Name, string[] Permissions);
+record ApiKeyRequest(string Name, string[] Permissions);
+record UploadedFile(string Path, string OriginalName);

--- a/server/Properties/launchSettings.json
+++ b/server/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:42338",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5266",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/server/VaultBackend.csproj
+++ b/server/VaultBackend.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.18" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>

--- a/server/VaultBackend.http
+++ b/server/VaultBackend.http
@@ -1,0 +1,6 @@
+@VaultBackend_HostAddress = http://localhost:5266
+
+GET {{VaultBackend_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/server/appsettings.Development.json
+++ b/server/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/server/appsettings.json
+++ b/server/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- add a basic ASP.NET Core API under `server`
- document how to run the backend in `README.md`

## Testing
- `npm install`
- `npm run lint` *(fails: Cannot find package '@eslint/js' etc.)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_b_687afd5b544483298731ec1a2e1878da