### PR TITLE
Add user management features

### DIFF
--- a/server/Controllers/AuthController.cs
+++ b/server/Controllers/AuthController.cs
@@ -30,13 +30,16 @@ namespace VaultBackend.Controllers
             {
                 Email = request.Email,
                 Name = request.Name,
-                PasswordHash = BCrypt.Net.BCrypt.HashPassword(request.Password)
+                PasswordHash = BCrypt.Net.BCrypt.HashPassword(request.Password),
+                Role = "user",
+                Status = "active",
+                LastLogin = DateTime.UtcNow
             };
             _db.Users.Add(user);
             await _db.SaveChangesAsync();
 
             var token = _tokens.GenerateToken(user);
-            return Ok(new { user.Id, user.Email, user.Name, token });
+            return Ok(new { user.Id, user.Email, user.Name, user.Role, user.Status, token });
         }
 
         [HttpPost("login")]
@@ -46,8 +49,11 @@ namespace VaultBackend.Controllers
             if (user == null || !BCrypt.Net.BCrypt.Verify(request.Password, user.PasswordHash))
                 return BadRequest("Invalid credentials");
 
+            user.LastLogin = DateTime.UtcNow;
+            await _db.SaveChangesAsync();
+
             var token = _tokens.GenerateToken(user);
-            return Ok(new { user.Id, user.Email, user.Name, token });
+            return Ok(new { user.Id, user.Email, user.Name, user.Role, user.Status, token });
         }
     }
 

--- a/server/Controllers/AuthController.cs
+++ b/server/Controllers/AuthController.cs
@@ -33,13 +33,14 @@ namespace VaultBackend.Controllers
                 PasswordHash = BCrypt.Net.BCrypt.HashPassword(request.Password),
                 Role = "user",
                 Status = "active",
-                LastLogin = DateTime.UtcNow
+                LastLogin = DateTime.UtcNow,
+                CreatedAt = DateTime.UtcNow
             };
             _db.Users.Add(user);
             await _db.SaveChangesAsync();
 
             var token = _tokens.GenerateToken(user);
-            return Ok(new { user.Id, user.Email, user.Name, user.Role, user.Status, user.LastLogin, token });
+            return Ok(new { user.Id, user.Email, user.Name, user.Role, user.Status, user.CreatedAt, user.LastLogin, token });
         }
 
         [HttpPost("login")]
@@ -53,7 +54,7 @@ namespace VaultBackend.Controllers
             await _db.SaveChangesAsync();
 
             var token = _tokens.GenerateToken(user);
-            return Ok(new { user.Id, user.Email, user.Name, user.Role, user.Status, user.LastLogin, token });
+            return Ok(new { user.Id, user.Email, user.Name, user.Role, user.Status, user.CreatedAt, user.LastLogin, token });
         }
     }
 

--- a/server/Controllers/AuthController.cs
+++ b/server/Controllers/AuthController.cs
@@ -39,7 +39,7 @@ namespace VaultBackend.Controllers
             await _db.SaveChangesAsync();
 
             var token = _tokens.GenerateToken(user);
-            return Ok(new { user.Id, user.Email, user.Name, user.Role, user.Status, token });
+            return Ok(new { user.Id, user.Email, user.Name, user.Role, user.Status, user.LastLogin, token });
         }
 
         [HttpPost("login")]
@@ -53,7 +53,7 @@ namespace VaultBackend.Controllers
             await _db.SaveChangesAsync();
 
             var token = _tokens.GenerateToken(user);
-            return Ok(new { user.Id, user.Email, user.Name, user.Role, user.Status, token });
+            return Ok(new { user.Id, user.Email, user.Name, user.Role, user.Status, user.LastLogin, token });
         }
     }
 

--- a/server/Controllers/UsersController.cs
+++ b/server/Controllers/UsersController.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using VaultBackend.Data;
+using VaultBackend.Models;
+
+namespace VaultBackend.Controllers
+{
+    [ApiController]
+    [Authorize(Roles = "admin")]
+    [Route("api/user")]
+    public class UsersController : ControllerBase
+    {
+        private readonly AppDbContext _db;
+
+        public UsersController(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetUsers()
+        {
+            var users = await _db.Users
+                .Select(u => new { u.Id, u.Email, u.Name, u.Role, u.Status, u.LastLogin })
+                .ToListAsync();
+            return Ok(users);
+        }
+
+        [HttpPatch("{id}")]
+        public async Task<IActionResult> UpdateUser(string id, UpdateUserRequest request)
+        {
+            var user = await _db.Users.FindAsync(id);
+            if (user == null) return NotFound();
+
+            if (!string.IsNullOrEmpty(request.Name)) user.Name = request.Name;
+            if (!string.IsNullOrEmpty(request.Role)) user.Role = request.Role;
+            if (!string.IsNullOrEmpty(request.Status)) user.Status = request.Status;
+
+            await _db.SaveChangesAsync();
+            return Ok(new { user.Id, user.Email, user.Name, user.Role, user.Status, user.LastLogin });
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteUser(string id)
+        {
+            var user = await _db.Users.FindAsync(id);
+            if (user == null) return NotFound();
+            _db.Users.Remove(user);
+            await _db.SaveChangesAsync();
+            return Ok();
+        }
+    }
+
+    public record UpdateUserRequest(string? Name, string? Role, string? Status);
+}

--- a/server/Models/User.cs
+++ b/server/Models/User.cs
@@ -22,5 +22,7 @@ namespace VaultBackend.Models
         public string Status { get; set; } = "active";
 
         public DateTime? LastLogin { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     }
 }

--- a/server/Models/User.cs
+++ b/server/Models/User.cs
@@ -16,5 +16,11 @@ namespace VaultBackend.Models
 
         [Required]
         public string PasswordHash { get; set; } = string.Empty;
+
+        public string Role { get; set; } = "user";
+
+        public string Status { get; set; } = "active";
+
+        public DateTime? LastLogin { get; set; }
     }
 }

--- a/server/Services/TokenService.cs
+++ b/server/Services/TokenService.cs
@@ -23,7 +23,8 @@ namespace VaultBackend.Services
                 {
                     new Claim(JwtRegisteredClaimNames.Sub, user.Id),
                     new Claim(JwtRegisteredClaimNames.Email, user.Email),
-                    new Claim("name", user.Name)
+                    new Claim("name", user.Name),
+                    new Claim(ClaimTypes.Role, user.Role)
                 },
                 expires: DateTime.UtcNow.AddHours(1),
                 signingCredentials: creds

--- a/src/components/ProfileDropdown.tsx
+++ b/src/components/ProfileDropdown.tsx
@@ -33,9 +33,19 @@ export function ProfileDropdown({ user, t, logout, show, onClose }: ProfileDropd
       <div className="px-4 py-3 border-b border-gray-200">
         <p className="text-sm font-bold text-gray-900">{user?.name || 'User'}</p>
         <p className="text-sm text-gray-600">{user?.email || 'user@example.com'}</p>
-        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 mt-1">
-          {user?.role || 'User'}
-        </span>
+        <div className="flex items-center gap-1 mt-1">
+          <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+            {user?.role || 'User'}
+          </span>
+          {user?.status && (
+            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+              {user.status}
+            </span>
+          )}
+        </div>
+        {user?.lastLogin && (
+          <p className="text-xs text-gray-500 mt-1">Last login: {new Date(user.lastLogin).toLocaleString()}</p>
+        )}
       </div>
       <div className="py-1">
         <button className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-primary-50/60 rounded-xl">

--- a/src/components/pages/UsersPage.tsx
+++ b/src/components/pages/UsersPage.tsx
@@ -1,15 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import {
   Users,
   UserPlus,
   Search,
   Filter,
-  MoreHorizontal, 
-  Edit, 
-  Trash2, 
-  Shield, 
-  Mail, 
-  Calendar, 
+  MoreHorizontal,
+  Edit,
+  Trash2,
+  Shield,
+  Mail,
+  Calendar,
   Clock,
   CheckCircle,
   XCircle,
@@ -18,58 +18,66 @@ import {
   User,
   Eye,
   Settings,
-  Key
-} from 'lucide-react';
-import { fetchUsers, createUser, updateUser, removeUser } from '../../utils/users';
+  Key,
+} from "lucide-react";
+import {
+  fetchUsers,
+  createUser,
+  updateUser,
+  removeUser,
+  ApiUser,
+} from "../../utils/users";
+import { useAuth } from "../../contexts/AuthContext";
 
 export interface UserItem {
   id: string;
   name: string;
   email: string;
-  role: 'admin' | 'editor' | 'contributor' | 'viewer';
-  status: 'active' | 'pending' | 'inactive' | 'suspended';
+  role: "admin" | "editor" | "contributor" | "viewer";
+  status: "active" | "pending" | "inactive" | "suspended";
   lastLogin: string | null;
-  joinDate: string;
+  createdAt: string;
   permissions: string[];
   avatar: string;
 }
 
-
 const roles = [
   {
-    name: 'Admin',
-    value: 'admin',
-    description: 'Full access to all features and settings',
-    permissions: ['read', 'write', 'delete', 'admin', 'user_management'],
-    color: 'bg-red-100 text-red-800 border-red-200'
+    name: "Admin",
+    value: "admin",
+    description: "Full access to all features and settings",
+    permissions: ["read", "write", "delete", "admin", "user_management"],
+    color: "bg-red-100 text-red-800 border-red-200",
   },
   {
-    name: 'Editor',
-    value: 'editor',
-    description: 'Can create, edit, and manage content',
-    permissions: ['read', 'write', 'delete'],
-    color: 'bg-blue-100 text-blue-800 border-blue-200'
+    name: "Editor",
+    value: "editor",
+    description: "Can create, edit, and manage content",
+    permissions: ["read", "write", "delete"],
+    color: "bg-blue-100 text-blue-800 border-blue-200",
   },
   {
-    name: 'Contributor',
-    value: 'contributor',
-    description: 'Can add content and make suggestions',
-    permissions: ['read', 'write'],
-    color: 'bg-green-100 text-green-800 border-green-200'
+    name: "Contributor",
+    value: "contributor",
+    description: "Can add content and make suggestions",
+    permissions: ["read", "write"],
+    color: "bg-green-100 text-green-800 border-green-200",
   },
   {
-    name: 'Viewer',
-    value: 'viewer',
-    description: 'Read-only access to content',
-    permissions: ['read'],
-    color: 'bg-gray-100 text-gray-800 border-gray-200'
-  }
+    name: "Viewer",
+    value: "viewer",
+    description: "Read-only access to content",
+    permissions: ["read"],
+    color: "bg-gray-100 text-gray-800 border-gray-200",
+  },
 ];
 
 export function UsersPage() {
-  const [searchTerm, setSearchTerm] = useState('');
-  const [filterRole, setFilterRole] = useState('all');
-  const [filterStatus, setFilterStatus] = useState('all');
+  const { isAuthenticated } = useAuth();
+  const token = localStorage.getItem("vault_token") || "";
+  const [searchTerm, setSearchTerm] = useState("");
+  const [filterRole, setFilterRole] = useState("all");
+  const [filterStatus, setFilterStatus] = useState("all");
   const [showInviteModal, setShowInviteModal] = useState(false);
   const [selectedUsers, setSelectedUsers] = useState<string[]>([]);
   const [showProfileModal, setShowProfileModal] = useState<string | null>(null);
@@ -77,72 +85,106 @@ export function UsersPage() {
   const [users, setUsers] = useState<UserItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [form, setForm] = useState({ name: '', email: '', role: 'viewer' });
+  const [form, setForm] = useState({ name: "", email: "", role: "viewer" });
 
   useEffect(() => {
+    if (!isAuthenticated) return;
     const load = async () => {
       setLoading(true);
       setError(null);
       try {
-        const data = await fetchUsers();
-        setUsers(data);
+        const data = await fetchUsers(token);
+        setUsers(
+          data.map((u: ApiUser) => ({
+            id: u.id,
+            name: u.name,
+            email: u.email,
+            role: u.role,
+            status: u.status,
+            lastLogin: u.lastLogin,
+            createdAt: u.createdAt,
+            permissions: roles.find((r) => r.value === u.role)?.permissions || [
+              "read",
+            ],
+            avatar: `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(u.name)}`,
+          })),
+        );
       } catch (e) {
         console.error(e);
-        setError('Failed to load users');
+        setError("Failed to load users");
       } finally {
         setLoading(false);
       }
     };
     load();
-  }, []);
+  }, [isAuthenticated, token]);
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'active': return 'bg-green-100 text-green-800 border-green-200';
-      case 'pending': return 'bg-yellow-100 text-yellow-800 border-yellow-200';
-      case 'inactive': return 'bg-gray-100 text-gray-800 border-gray-200';
-      case 'suspended': return 'bg-red-100 text-red-800 border-red-200';
-      default: return 'bg-gray-100 text-gray-800 border-gray-200';
+      case "active":
+        return "bg-green-100 text-green-800 border-green-200";
+      case "pending":
+        return "bg-yellow-100 text-yellow-800 border-yellow-200";
+      case "inactive":
+        return "bg-gray-100 text-gray-800 border-gray-200";
+      case "suspended":
+        return "bg-red-100 text-red-800 border-red-200";
+      default:
+        return "bg-gray-100 text-gray-800 border-gray-200";
     }
   };
 
   const getStatusIcon = (status: string) => {
     switch (status) {
-      case 'active': return CheckCircle;
-      case 'pending': return Clock;
-      case 'inactive': return XCircle;
-      case 'suspended': return AlertTriangle;
-      default: return XCircle;
+      case "active":
+        return CheckCircle;
+      case "pending":
+        return Clock;
+      case "inactive":
+        return XCircle;
+      case "suspended":
+        return AlertTriangle;
+      default:
+        return XCircle;
     }
   };
 
   const getRoleIcon = (role: string) => {
     switch (role) {
-      case 'admin': return Crown;
-      case 'editor': return Edit;
-      case 'contributor': return UserPlus;
-      case 'viewer': return Eye;
-      default: return User;
+      case "admin":
+        return Crown;
+      case "editor":
+        return Edit;
+      case "contributor":
+        return UserPlus;
+      case "viewer":
+        return Eye;
+      default:
+        return User;
     }
   };
 
   const getRoleColor = (role: string) => {
-    const roleData = roles.find(r => r.value === role);
-    return roleData?.color || 'bg-gray-100 text-gray-800 border-gray-200';
+    const roleData = roles.find((r) => r.value === role);
+    return roleData?.color || "bg-gray-100 text-gray-800 border-gray-200";
   };
 
   const formatLastLogin = (lastLogin: string | null) => {
-    if (!lastLogin) return 'Never';
+    if (!lastLogin) return "Never";
     const date = new Date(lastLogin);
-    return date.toLocaleDateString() + ' ' + date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return (
+      date.toLocaleDateString() +
+      " " +
+      date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+    );
   };
 
-  const filteredUsers = users.filter(u => {
+  const filteredUsers = users.filter((u) => {
     const matchSearch =
       u.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
       u.email.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchRole = filterRole === 'all' || u.role === filterRole;
-    const matchStatus = filterStatus === 'all' || u.status === filterStatus;
+    const matchRole = filterRole === "all" || u.role === filterRole;
+    const matchStatus = filterStatus === "all" || u.status === filterStatus;
     return matchSearch && matchRole && matchStatus;
   });
 
@@ -153,14 +195,14 @@ export function UsersPage() {
   };
 
   const handleDelete = async (id: string) => {
-    if (confirm('Remove this user?')) {
+    if (confirm("Remove this user?")) {
       try {
-        await removeUser(id);
+        await removeUser(token, id);
         setUsers((prev) => prev.filter((u) => u.id !== id));
         setSelectedUsers((prev) => prev.filter((uid) => uid !== id));
       } catch (err) {
         console.error(err);
-        alert('Failed to remove user');
+        alert("Failed to remove user");
       }
     }
   };
@@ -172,61 +214,90 @@ export function UsersPage() {
   const handleInviteSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const roleInfo = roles.find((r) => r.value === form.role);
-    const newUser: UserItem = {
-      id: editingId ?? Date.now().toString(),
-      name: form.name,
-      email: form.email,
-      role: form.role as UserItem['role'],
-      status: editingId ? users.find((u) => u.id === editingId)!.status : 'pending',
-      lastLogin: editingId ? users.find((u) => u.id === editingId)!.lastLogin : null,
-      joinDate: editingId ? users.find((u) => u.id === editingId)!.joinDate : new Date().toISOString().split('T')[0],
-      permissions: roleInfo?.permissions ?? ['read'],
-      avatar: `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(form.name)}`,
-    };
 
     try {
       if (editingId) {
-        await updateUser(editingId, newUser);
-        setUsers((prev) => prev.map((u) => (u.id === editingId ? { ...u, ...newUser } : u)));
+        const updated = await updateUser(token, editingId, {
+          name: form.name,
+          role: form.role,
+        });
+        setUsers((prev) =>
+          prev.map((u) =>
+            u.id === editingId
+              ? {
+                  ...u,
+                  name: updated.name,
+                  role: updated.role,
+                }
+              : u,
+          ),
+        );
       } else {
-        await createUser(newUser);
+        const created = await createUser(token, {
+          name: form.name,
+          email: form.email,
+          role: form.role,
+        });
+        const newUser: UserItem = {
+          id: created.id,
+          name: created.name,
+          email: created.email,
+          role: created.role as UserItem["role"],
+          status: created.status as UserItem["status"],
+          lastLogin: created.lastLogin,
+          createdAt: created.createdAt,
+          permissions: roleInfo?.permissions ?? ["read"],
+          avatar: `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(created.name)}`,
+        };
         setUsers((prev) => [newUser, ...prev]);
       }
     } catch (err) {
       console.error(err);
-      alert('Failed to save user');
+      alert("Failed to save user");
     }
     setEditingId(null);
-    setForm({ name: '', email: '', role: 'viewer' });
+    setForm({ name: "", email: "", role: "viewer" });
     setShowInviteModal(false);
   };
 
   const sendBulkMessage = () => {
-    const names = users.filter((u) => selectedUsers.includes(u.id)).map((u) => u.name).join(', ');
+    const names = users
+      .filter((u) => selectedUsers.includes(u.id))
+      .map((u) => u.name)
+      .join(", ");
     alert(`Message sent to: ${names}`);
   };
 
   const bulkChangeRole = async () => {
-    const role = prompt('Enter new role (admin, editor, contributor, viewer):', 'viewer');
+    const role = prompt(
+      "Enter new role (admin, editor, contributor, viewer):",
+      "viewer",
+    );
     if (!role) return;
     try {
-      await Promise.all(selectedUsers.map(id => updateUser(id, { role: role as UserItem['role'] })));
-      setUsers((prev) => prev.map((u) => (selectedUsers.includes(u.id) ? { ...u, role } : u)));
+      await Promise.all(
+        selectedUsers.map((id) =>
+          updateUser(token, id, { role: role as UserItem["role"] }),
+        ),
+      );
+      setUsers((prev) =>
+        prev.map((u) => (selectedUsers.includes(u.id) ? { ...u, role } : u)),
+      );
     } catch (err) {
       console.error(err);
-      alert('Failed to update roles');
+      alert("Failed to update roles");
     }
   };
 
   const bulkRemove = async () => {
-    if (confirm('Remove selected users?')) {
+    if (confirm("Remove selected users?")) {
       try {
-        await Promise.all(selectedUsers.map(id => removeUser(id)));
+        await Promise.all(selectedUsers.map((id) => removeUser(token, id)));
         setUsers((prev) => prev.filter((u) => !selectedUsers.includes(u.id)));
         setSelectedUsers([]);
       } catch (err) {
         console.error(err);
-        alert('Failed to remove users');
+        alert("Failed to remove users");
       }
     }
   };
@@ -242,17 +313,27 @@ export function UsersPage() {
   return (
     <div className="relative min-h-screen pb-24">
       {/* Animated Glassy Hero */}
-      <div className="relative z-10 flex flex-col sm:flex-row sm:items-center sm:justify-between px-6 pt-10 pb-8 mb-6 rounded-3xl bg-white/60 backdrop-blur-lg shadow-xl border border-white/30 overflow-hidden" style={{background: 'linear-gradient(120deg,rgba(59,130,246,0.08),rgba(236,72,153,0.08) 100%)'}}>
+      <div
+        className="relative z-10 flex flex-col sm:flex-row sm:items-center sm:justify-between px-6 pt-10 pb-8 mb-6 rounded-3xl bg-white/60 backdrop-blur-lg shadow-xl border border-white/30 overflow-hidden"
+        style={{
+          background:
+            "linear-gradient(120deg,rgba(59,130,246,0.08),rgba(236,72,153,0.08) 100%)",
+        }}
+      >
         <div>
-          <h1 className="text-4xl font-extrabold text-gray-900 drop-shadow-sm">User Management</h1>
-          <p className="mt-2 text-lg text-gray-700">Manage user accounts, roles, and permissions</p>
+          <h1 className="text-4xl font-extrabold text-gray-900 drop-shadow-sm">
+            User Management
+          </h1>
+          <p className="mt-2 text-lg text-gray-700">
+            Manage user accounts, roles, and permissions
+          </p>
         </div>
         <div className="mt-6 sm:mt-0 flex space-x-3">
           <button className="inline-flex items-center px-4 py-2 border border-gray-200 rounded-xl text-sm font-semibold text-gray-700 bg-white/80 hover:bg-blue-50 shadow transition">
             <Settings className="h-4 w-4 mr-2" />
             Permissions
           </button>
-          <button 
+          <button
             onClick={() => setShowInviteModal(true)}
             className="inline-flex items-center px-4 py-2 border border-transparent rounded-xl text-sm font-semibold text-white bg-gradient-to-r from-blue-600 to-pink-500 shadow-lg hover:scale-105 hover:shadow-xl transition"
           >
@@ -268,18 +349,42 @@ export function UsersPage() {
       {/* Animated Stats */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-6">
         {[
-          { icon: <Users className="h-7 w-7 text-blue-600" />, label: 'Total Users', value: users.length, color: 'from-blue-100 to-blue-50' },
-          { icon: <CheckCircle className="h-7 w-7 text-green-600" />, label: 'Active', value: users.filter(u => u.status === 'active').length, color: 'from-green-100 to-green-50' },
-          { icon: <Clock className="h-7 w-7 text-yellow-600" />, label: 'Pending', value: users.filter(u => u.status === 'pending').length, color: 'from-yellow-100 to-yellow-50' },
-          { icon: <Crown className="h-7 w-7 text-red-600" />, label: 'Admins', value: users.filter(u => u.role === 'admin').length, color: 'from-red-100 to-red-50' },
+          {
+            icon: <Users className="h-7 w-7 text-blue-600" />,
+            label: "Total Users",
+            value: users.length,
+            color: "from-blue-100 to-blue-50",
+          },
+          {
+            icon: <CheckCircle className="h-7 w-7 text-green-600" />,
+            label: "Active",
+            value: users.filter((u) => u.status === "active").length,
+            color: "from-green-100 to-green-50",
+          },
+          {
+            icon: <Clock className="h-7 w-7 text-yellow-600" />,
+            label: "Pending",
+            value: users.filter((u) => u.status === "pending").length,
+            color: "from-yellow-100 to-yellow-50",
+          },
+          {
+            icon: <Crown className="h-7 w-7 text-red-600" />,
+            label: "Admins",
+            value: users.filter((u) => u.role === "admin").length,
+            color: "from-red-100 to-red-50",
+          },
         ].map((stat, i) => (
-          <div key={stat.label} className={`bg-gradient-to-br ${stat.color} p-6 rounded-2xl border border-white/40 shadow flex items-center space-x-4 glassy-card animate-fade-in`} style={{animationDelay: `${i * 80}ms`}}>
-            <div className="p-3 bg-white/60 rounded-xl shadow">
-              {stat.icon}
-            </div>
+          <div
+            key={stat.label}
+            className={`bg-gradient-to-br ${stat.color} p-6 rounded-2xl border border-white/40 shadow flex items-center space-x-4 glassy-card animate-fade-in`}
+            style={{ animationDelay: `${i * 80}ms` }}
+          >
+            <div className="p-3 bg-white/60 rounded-xl shadow">{stat.icon}</div>
             <div>
               <p className="text-sm font-medium text-gray-600">{stat.label}</p>
-              <p className="text-2xl font-extrabold text-gray-900 tracking-tight">{stat.value}</p>
+              <p className="text-2xl font-extrabold text-gray-900 tracking-tight">
+                {stat.value}
+              </p>
             </div>
           </div>
         ))}
@@ -287,25 +392,39 @@ export function UsersPage() {
 
       {/* Interactive Roles Overview */}
       <div className="bg-white/70 rounded-3xl border border-white/30 p-6 mb-6 shadow-xl backdrop-blur-lg">
-        <h3 className="text-lg font-bold text-gray-900 mb-4">User Roles & Permissions</h3>
+        <h3 className="text-lg font-bold text-gray-900 mb-4">
+          User Roles & Permissions
+        </h3>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5">
           {roles.map((role) => {
             const RoleIcon = getRoleIcon(role.value);
             return (
-              <div key={role.value} className="glassy-card border border-white/40 rounded-2xl p-5 shadow-lg hover:scale-[1.03] hover:shadow-2xl transition group relative overflow-hidden">
+              <div
+                key={role.value}
+                className="glassy-card border border-white/40 rounded-2xl p-5 shadow-lg hover:scale-[1.03] hover:shadow-2xl transition group relative overflow-hidden"
+              >
                 <div className="absolute -top-6 -right-6 w-16 h-16 bg-blue-400/10 rounded-full blur-xl group-hover:scale-125 transition" />
                 <div className="flex items-center space-x-3 mb-2 relative z-10">
                   <div className="p-2 bg-white/60 rounded-xl shadow">
                     <RoleIcon className="h-5 w-5 text-gray-600" />
                   </div>
-                  <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold border ${role.color}`}>{role.name}</span>
+                  <span
+                    className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold border ${role.color}`}
+                  >
+                    {role.name}
+                  </span>
                 </div>
-                <p className="text-sm text-gray-600 mb-3 relative z-10">{role.description}</p>
+                <p className="text-sm text-gray-600 mb-3 relative z-10">
+                  {role.description}
+                </p>
                 <div className="space-y-1 relative z-10">
                   {role.permissions.map((permission) => (
-                    <div key={permission} className="flex items-center text-xs text-gray-500">
+                    <div
+                      key={permission}
+                      className="flex items-center text-xs text-gray-500"
+                    >
                       <CheckCircle className="h-3 w-3 text-green-500 mr-1" />
-                      {permission.replace('_', ' ')}
+                      {permission.replace("_", " ")}
                     </div>
                   ))}
                 </div>
@@ -337,7 +456,9 @@ export function UsersPage() {
           >
             <option value="all">All Roles</option>
             {roles.map((role) => (
-              <option key={role.value} value={role.value}>{role.name}</option>
+              <option key={role.value} value={role.value}>
+                {role.name}
+              </option>
             ))}
           </select>
           <select
@@ -367,7 +488,11 @@ export function UsersPage() {
             const StatusIcon = getStatusIcon(user.status);
             const RoleIcon = getRoleIcon(user.role);
             return (
-              <div key={user.id} className="p-6 hover:bg-blue-50/20 transition cursor-pointer group" onClick={() => setShowProfileModal(user.id)}>
+              <div
+                key={user.id}
+                className="p-6 hover:bg-blue-50/20 transition cursor-pointer group"
+                onClick={() => setShowProfileModal(user.id)}
+              >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center space-x-4">
                     <input
@@ -377,11 +502,13 @@ export function UsersPage() {
                         if (e.target.checked) {
                           setSelectedUsers([...selectedUsers, user.id]);
                         } else {
-                          setSelectedUsers(selectedUsers.filter(id => id !== user.id));
+                          setSelectedUsers(
+                            selectedUsers.filter((id) => id !== user.id),
+                          );
                         }
                       }}
                       className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                      onClick={e => e.stopPropagation()}
+                      onClick={(e) => e.stopPropagation()}
                     />
                     <img
                       src={user.avatar}
@@ -389,19 +516,31 @@ export function UsersPage() {
                       className="w-12 h-12 rounded-full object-cover border-2 border-white shadow group-hover:scale-105 transition"
                     />
                     <div>
-                      <h4 className="text-lg font-bold text-gray-900 group-hover:text-blue-700 transition">{user.name}</h4>
+                      <h4 className="text-lg font-bold text-gray-900 group-hover:text-blue-700 transition">
+                        {user.name}
+                      </h4>
                       <div className="flex items-center space-x-2 mt-1">
                         <Mail className="h-4 w-4 text-gray-400" />
-                        <span className="text-sm text-gray-600">{user.email}</span>
+                        <span className="text-sm text-gray-600">
+                          {user.email}
+                        </span>
                       </div>
                       <div className="flex items-center space-x-4 mt-2">
                         <div className="flex items-center space-x-1">
                           <RoleIcon className="h-4 w-4 text-gray-400" />
-                          <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold border ${getRoleColor(user.role)}`}>{user.role}</span>
+                          <span
+                            className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold border ${getRoleColor(user.role)}`}
+                          >
+                            {user.role}
+                          </span>
                         </div>
                         <div className="flex items-center space-x-1">
                           <StatusIcon className="h-4 w-4 text-gray-400" />
-                          <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold border ${getStatusColor(user.status)}`}>{user.status}</span>
+                          <span
+                            className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold border ${getStatusColor(user.status)}`}
+                          >
+                            {user.status}
+                          </span>
                         </div>
                       </div>
                     </div>
@@ -410,7 +549,7 @@ export function UsersPage() {
                     <div className="text-right">
                       <div className="flex items-center text-sm text-gray-500 mb-1">
                         <Calendar className="h-4 w-4 mr-1" />
-                        Joined {user.joinDate}
+                        Joined {new Date(user.createdAt).toLocaleDateString()}
                       </div>
                       <div className="flex items-center text-sm text-gray-500">
                         <Clock className="h-4 w-4 mr-1" />
@@ -445,7 +584,10 @@ export function UsersPage() {
                       >
                         <Trash2 className="h-4 w-4" />
                       </button>
-                      <button className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-50 transition" onClick={e => e.stopPropagation()}>
+                      <button
+                        className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-50 transition"
+                        onClick={(e) => e.stopPropagation()}
+                      >
                         <MoreHorizontal className="h-4 w-4" />
                       </button>
                     </div>
@@ -470,10 +612,18 @@ export function UsersPage() {
       {showInviteModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
           <div className="bg-white rounded-2xl shadow-2xl p-8 w-full max-w-lg relative animate-fade-in">
-            <button className="absolute top-3 right-3 text-gray-400 hover:text-red-500" onClick={() => { setShowInviteModal(false); setEditingId(null); }}>
+            <button
+              className="absolute top-3 right-3 text-gray-400 hover:text-red-500"
+              onClick={() => {
+                setShowInviteModal(false);
+                setEditingId(null);
+              }}
+            >
               &times;
             </button>
-            <h2 className="text-xl font-bold mb-4 text-gray-900">{editingId ? 'Edit User' : 'Invite New User'}</h2>
+            <h2 className="text-xl font-bold mb-4 text-gray-900">
+              {editingId ? "Edit User" : "Invite New User"}
+            </h2>
             <form className="space-y-4" onSubmit={handleInviteSubmit}>
               <input
                 className="w-full border border-gray-200 rounded-lg px-3 py-2"
@@ -502,11 +652,21 @@ export function UsersPage() {
                 ))}
               </select>
               <div className="flex space-x-2">
-                <button type="button" className="flex-1 py-2 rounded-lg bg-gray-100 text-gray-700 font-semibold hover:bg-gray-200" onClick={() => { setShowInviteModal(false); setEditingId(null); }}>
+                <button
+                  type="button"
+                  className="flex-1 py-2 rounded-lg bg-gray-100 text-gray-700 font-semibold hover:bg-gray-200"
+                  onClick={() => {
+                    setShowInviteModal(false);
+                    setEditingId(null);
+                  }}
+                >
                   Cancel
                 </button>
-                <button type="submit" className="flex-1 py-2 rounded-lg bg-blue-600 text-white font-semibold hover:bg-blue-700">
-                  {editingId ? 'Save' : 'Invite'}
+                <button
+                  type="submit"
+                  className="flex-1 py-2 rounded-lg bg-blue-600 text-white font-semibold hover:bg-blue-700"
+                >
+                  {editingId ? "Save" : "Invite"}
                 </button>
               </div>
             </form>
@@ -515,50 +675,88 @@ export function UsersPage() {
       )}
 
       {/* User Profile Quick View Modal (UI only) */}
-      {showProfileModal && (() => {
-        const user = users.find(u => u.id === showProfileModal);
-        if (!user) return null;
-        const StatusIcon = getStatusIcon(user.status);
-        const RoleIcon = getRoleIcon(user.role);
-        return (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm" onClick={() => setShowProfileModal(null)}>
-            <div className="bg-white rounded-2xl shadow-2xl p-8 w-full max-w-md relative animate-fade-in" onClick={e => e.stopPropagation()}>
-              <button className="absolute top-3 right-3 text-gray-400 hover:text-red-500" onClick={() => setShowProfileModal(null)}>
-                <Trash2 className="h-5 w-5" />
-              </button>
-              <div className="flex flex-col items-center mb-4">
-                <img src={user.avatar} alt={user.name} className="w-20 h-20 rounded-full object-cover border-4 border-blue-200 shadow mb-2" />
-                <h3 className="text-xl font-bold text-gray-900">{user.name}</h3>
-                <span className="text-sm text-gray-500">{user.email}</span>
-                <div className="flex items-center space-x-2 mt-2">
-                  <RoleIcon className="h-4 w-4 text-gray-400" />
-                  <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold border ${getRoleColor(user.role)}`}>{user.role}</span>
-                  <StatusIcon className="h-4 w-4 text-gray-400" />
-                  <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold border ${getStatusColor(user.status)}`}>{user.status}</span>
+      {showProfileModal &&
+        (() => {
+          const user = users.find((u) => u.id === showProfileModal);
+          if (!user) return null;
+          const StatusIcon = getStatusIcon(user.status);
+          const RoleIcon = getRoleIcon(user.role);
+          return (
+            <div
+              className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+              onClick={() => setShowProfileModal(null)}
+            >
+              <div
+                className="bg-white rounded-2xl shadow-2xl p-8 w-full max-w-md relative animate-fade-in"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <button
+                  className="absolute top-3 right-3 text-gray-400 hover:text-red-500"
+                  onClick={() => setShowProfileModal(null)}
+                >
+                  <Trash2 className="h-5 w-5" />
+                </button>
+                <div className="flex flex-col items-center mb-4">
+                  <img
+                    src={user.avatar}
+                    alt={user.name}
+                    className="w-20 h-20 rounded-full object-cover border-4 border-blue-200 shadow mb-2"
+                  />
+                  <h3 className="text-xl font-bold text-gray-900">
+                    {user.name}
+                  </h3>
+                  <span className="text-sm text-gray-500">{user.email}</span>
+                  <div className="flex items-center space-x-2 mt-2">
+                    <RoleIcon className="h-4 w-4 text-gray-400" />
+                    <span
+                      className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold border ${getRoleColor(user.role)}`}
+                    >
+                      {user.role}
+                    </span>
+                    <StatusIcon className="h-4 w-4 text-gray-400" />
+                    <span
+                      className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold border ${getStatusColor(user.status)}`}
+                    >
+                      {user.status}
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div className="mb-2 text-sm text-gray-700">
-                <div className="flex items-center mb-1"><Calendar className="h-4 w-4 mr-1" />Joined {user.joinDate}</div>
-                <div className="flex items-center"><Clock className="h-4 w-4 mr-1" />Last login: {formatLastLogin(user.lastLogin)}</div>
-              </div>
-              <div className="mt-4">
-                <h4 className="font-semibold text-gray-800 mb-2">Permissions</h4>
-                <div className="flex flex-wrap gap-2">
-                  {user.permissions.map(p => (
-                    <span key={p} className="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold bg-blue-100 text-blue-800 border border-blue-200">{p}</span>
-                  ))}
+                <div className="mb-2 text-sm text-gray-700">
+                  <div className="flex items-center mb-1">
+                    <Calendar className="h-4 w-4 mr-1" />
+                    Joined {new Date(user.createdAt).toLocaleDateString()}
+                  </div>
+                  <div className="flex items-center">
+                    <Clock className="h-4 w-4 mr-1" />
+                    Last login: {formatLastLogin(user.lastLogin)}
+                  </div>
+                </div>
+                <div className="mt-4">
+                  <h4 className="font-semibold text-gray-800 mb-2">
+                    Permissions
+                  </h4>
+                  <div className="flex flex-wrap gap-2">
+                    {user.permissions.map((p) => (
+                      <span
+                        key={p}
+                        className="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold bg-blue-100 text-blue-800 border border-blue-200"
+                      >
+                        {p}
+                      </span>
+                    ))}
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        );
-      })()}
+          );
+        })()}
 
       {/* Bulk Actions */}
       {selectedUsers.length > 0 && (
         <div className="fixed bottom-6 left-1/2 transform -translate-x-1/2 bg-white/90 border border-white/30 rounded-xl shadow-2xl p-4 z-50 flex items-center space-x-4 animate-fade-in">
           <span className="text-sm font-semibold text-gray-700">
-            {selectedUsers.length} user{selectedUsers.length > 1 ? 's' : ''} selected
+            {selectedUsers.length} user{selectedUsers.length > 1 ? "s" : ""}{" "}
+            selected
           </span>
           <div className="flex space-x-2">
             <button

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,7 +1,13 @@
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { User, AuthState } from '../types';
-import { EncryptionService } from '../utils/encryption';
-import { blockchain } from '../utils/blockchain';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  ReactNode,
+} from "react";
+import { User, AuthState } from "../types";
+import { EncryptionService } from "../utils/encryption";
+import { blockchain } from "../utils/blockchain";
 
 interface AuthContextType extends AuthState {
   login: (email: string, password: string) => Promise<void>;
@@ -16,7 +22,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 export function useAuth() {
   const context = useContext(AuthContext);
   if (context === undefined) {
-    throw new Error('useAuth must be used within an AuthProvider');
+    throw new Error("useAuth must be used within an AuthProvider");
   }
   return context;
 }
@@ -37,11 +43,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
     // Check for existing session
     const checkAuth = () => {
       try {
-        const encryptedUser = localStorage.getItem('vault_user');
-        const token = localStorage.getItem('vault_token');
+        const encryptedUser = localStorage.getItem("vault_user");
+        const token = localStorage.getItem("vault_token");
         if (encryptedUser && token) {
-          const decrypted = JSON.parse(EncryptionService.decrypt(encryptedUser));
-          const userData = { status: 'active', ...decrypted } as User;
+          const decrypted = JSON.parse(
+            EncryptionService.decrypt(encryptedUser),
+          );
+          const userData = { status: "active", ...decrypted } as User;
           setAuthState({
             user: userData,
             isAuthenticated: true,
@@ -49,11 +57,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
             error: null,
           });
         } else {
-          setAuthState(prev => ({ ...prev, isLoading: false }));
+          setAuthState((prev) => ({ ...prev, isLoading: false }));
         }
       } catch (err) {
         console.error(err);
-        setAuthState(prev => ({ ...prev, isLoading: false, error: 'Session validation failed' }));
+        setAuthState((prev) => ({
+          ...prev,
+          isLoading: false,
+          error: "Session validation failed",
+        }));
       }
     };
 
@@ -61,38 +73,47 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   const login = async (email: string, password: string): Promise<void> => {
-    setAuthState(prev => ({ ...prev, isLoading: true, error: null }));
+    setAuthState((prev) => ({ ...prev, isLoading: true, error: null }));
 
     try {
-      const res = await fetch('/api/auth/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const res = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, password }),
       });
 
       if (!res.ok) throw new Error(await res.text());
 
-      const data: { id: string; email: string; name: string; role: string; status: string; lastLogin: string | null; token: string } = await res.json();
+      const data: {
+        id: string;
+        email: string;
+        name: string;
+        role: string;
+        status: string;
+        createdAt: string;
+        lastLogin: string | null;
+        token: string;
+      } = await res.json();
 
       const user: User = {
         id: data.id,
         email: data.email,
         name: data.name,
-        role: data.role as User['role'],
-        status: data.status as User['status'],
-        createdAt: new Date(),
+        role: data.role as User["role"],
+        status: data.status as User["status"],
+        createdAt: new Date(data.createdAt),
         lastLogin: data.lastLogin ? new Date(data.lastLogin) : undefined,
       };
 
-      localStorage.setItem('vault_token', data.token);
+      localStorage.setItem("vault_token", data.token);
       const encryptedUser = EncryptionService.encrypt(JSON.stringify(user));
-      localStorage.setItem('vault_user', encryptedUser);
+      localStorage.setItem("vault_user", encryptedUser);
 
       blockchain.addBlock({
-        type: 'user_login',
+        type: "user_login",
         userId: user.id,
         timestamp: new Date(),
-        ip: '0.0.0.0'
+        ip: "0.0.0.0",
       });
 
       setAuthState({
@@ -103,47 +124,60 @@ export function AuthProvider({ children }: AuthProviderProps) {
       });
     } catch (err) {
       console.error(err);
-      setAuthState(prev => ({
+      setAuthState((prev) => ({
         ...prev,
         isLoading: false,
-        error: 'Invalid credentials'
+        error: "Invalid credentials",
       }));
     }
   };
 
-  const signup = async (email: string, password: string, name: string): Promise<void> => {
-    setAuthState(prev => ({ ...prev, isLoading: true, error: null }));
+  const signup = async (
+    email: string,
+    password: string,
+    name: string,
+  ): Promise<void> => {
+    setAuthState((prev) => ({ ...prev, isLoading: true, error: null }));
 
     try {
-      const res = await fetch('/api/auth/signup', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const res = await fetch("/api/auth/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, password, name }),
       });
 
       if (!res.ok) throw new Error(await res.text());
 
-      const data: { id: string; email: string; name: string; role: string; status: string; lastLogin: string | null; token: string } = await res.json();
+      const data: {
+        id: string;
+        email: string;
+        name: string;
+        role: string;
+        status: string;
+        createdAt: string;
+        lastLogin: string | null;
+        token: string;
+      } = await res.json();
 
       const user: User = {
         id: data.id,
         email: data.email,
         name: data.name,
-        role: data.role as User['role'],
-        status: data.status as User['status'],
-        createdAt: new Date(),
+        role: data.role as User["role"],
+        status: data.status as User["status"],
+        createdAt: new Date(data.createdAt),
         lastLogin: data.lastLogin ? new Date(data.lastLogin) : undefined,
       };
 
-      localStorage.setItem('vault_token', data.token);
+      localStorage.setItem("vault_token", data.token);
       const encryptedUser = EncryptionService.encrypt(JSON.stringify(user));
-      localStorage.setItem('vault_user', encryptedUser);
+      localStorage.setItem("vault_user", encryptedUser);
 
       blockchain.addBlock({
-        type: 'user_created',
+        type: "user_created",
         userId: user.id,
         email: user.email,
-        timestamp: new Date()
+        timestamp: new Date(),
       });
 
       setAuthState({
@@ -154,17 +188,17 @@ export function AuthProvider({ children }: AuthProviderProps) {
       });
     } catch (err) {
       console.error(err);
-      setAuthState(prev => ({
+      setAuthState((prev) => ({
         ...prev,
         isLoading: false,
-        error: 'Registration failed'
+        error: "Registration failed",
       }));
     }
   };
 
   const logout = () => {
-    localStorage.removeItem('vault_user');
-    localStorage.removeItem('vault_token');
+    localStorage.removeItem("vault_user");
+    localStorage.removeItem("vault_token");
     setAuthState({
       user: null,
       isAuthenticated: false,
@@ -174,51 +208,54 @@ export function AuthProvider({ children }: AuthProviderProps) {
   };
 
   const forgotPassword = async (email: string): Promise<void> => {
-    setAuthState(prev => ({ ...prev, isLoading: true, error: null }));
-    
+    setAuthState((prev) => ({ ...prev, isLoading: true, error: null }));
+
     try {
       // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
       // Add password reset request to blockchain
       blockchain.addBlock({
-        type: 'password_reset_requested',
+        type: "password_reset_requested",
         email,
-        timestamp: new Date()
+        timestamp: new Date(),
       });
 
-      setAuthState(prev => ({ ...prev, isLoading: false }));
+      setAuthState((prev) => ({ ...prev, isLoading: false }));
     } catch (err) {
       console.error(err);
-      setAuthState(prev => ({
+      setAuthState((prev) => ({
         ...prev,
         isLoading: false,
-        error: 'Failed to send reset email'
+        error: "Failed to send reset email",
       }));
     }
   };
 
-  const resetPassword = async (token: string, newPassword: string): Promise<void> => {
-    setAuthState(prev => ({ ...prev, isLoading: true, error: null }));
+  const resetPassword = async (
+    token: string,
+    newPassword: string,
+  ): Promise<void> => {
+    setAuthState((prev) => ({ ...prev, isLoading: true, error: null }));
 
     try {
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await new Promise((resolve) => setTimeout(resolve, 1000));
       void newPassword;
 
       // Add password reset to blockchain
       blockchain.addBlock({
-        type: 'password_reset_completed',
+        type: "password_reset_completed",
         token,
-        timestamp: new Date()
+        timestamp: new Date(),
       });
 
-      setAuthState(prev => ({ ...prev, isLoading: false }));
+      setAuthState((prev) => ({ ...prev, isLoading: false }));
     } catch (err) {
       console.error(err);
-      setAuthState(prev => ({
+      setAuthState((prev) => ({
         ...prev,
         isLoading: false,
-        error: 'Failed to reset password'
+        error: "Failed to reset password",
       }));
     }
   };

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -40,7 +40,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
         const encryptedUser = localStorage.getItem('vault_user');
         const token = localStorage.getItem('vault_token');
         if (encryptedUser && token) {
-          const userData = JSON.parse(EncryptionService.decrypt(encryptedUser));
+          const decrypted = JSON.parse(EncryptionService.decrypt(encryptedUser));
+          const userData = { status: 'active', ...decrypted } as User;
           setAuthState({
             user: userData,
             isAuthenticated: true,
@@ -71,15 +72,16 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
       if (!res.ok) throw new Error(await res.text());
 
-      const data: { id: string; email: string; name: string; token: string } = await res.json();
+      const data: { id: string; email: string; name: string; role: string; status: string; lastLogin: string | null; token: string } = await res.json();
 
       const user: User = {
         id: data.id,
         email: data.email,
         name: data.name,
-        role: 'user',
+        role: data.role as User['role'],
+        status: data.status as User['status'],
         createdAt: new Date(),
-        lastLogin: new Date(),
+        lastLogin: data.lastLogin ? new Date(data.lastLogin) : undefined,
       };
 
       localStorage.setItem('vault_token', data.token);
@@ -121,14 +123,16 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
       if (!res.ok) throw new Error(await res.text());
 
-      const data: { id: string; email: string; name: string; token: string } = await res.json();
+      const data: { id: string; email: string; name: string; role: string; status: string; lastLogin: string | null; token: string } = await res.json();
 
       const user: User = {
         id: data.id,
         email: data.email,
         name: data.name,
-        role: 'user',
+        role: data.role as User['role'],
+        status: data.status as User['status'],
         createdAt: new Date(),
+        lastLogin: data.lastLogin ? new Date(data.lastLogin) : undefined,
       };
 
       localStorage.setItem('vault_token', data.token);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@ export interface User {
   email: string;
   name: string;
   role: 'admin' | 'editor' | 'viewer';
+  status: 'active' | 'pending' | 'inactive' | 'suspended';
   avatar?: string;
   createdAt: Date;
   lastLogin?: Date;

--- a/src/utils/users.ts
+++ b/src/utils/users.ts
@@ -1,67 +1,60 @@
-export interface StoredUser {
+export interface ApiUser {
   id: string;
-  name: string;
   email: string;
-  role: 'admin' | 'editor' | 'contributor' | 'viewer';
-  status: 'active' | 'pending' | 'inactive' | 'suspended';
+  name: string;
+  role: "admin" | "editor" | "contributor" | "viewer";
+  status: "active" | "pending" | "inactive" | "suspended";
+  createdAt: string;
   lastLogin: string | null;
-  joinDate: string;
-  permissions: string[];
-  avatar: string;
 }
 
-const STORAGE_KEY = 'vault_users';
+const API_BASE = import.meta.env.VITE_API_URL || "";
 
-function readUsers(): StoredUser[] {
-  const raw = localStorage.getItem(STORAGE_KEY);
-  return raw ? JSON.parse(raw) : [];
-}
-
-function writeUsers(users: StoredUser[]) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(users));
-}
-
-export async function fetchUsers(): Promise<StoredUser[]> {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      resolve(readUsers());
-    }, 300);
+export async function fetchUsers(token: string): Promise<ApiUser[]> {
+  const res = await fetch(`${API_BASE}/api/user`, {
+    headers: { Authorization: `Bearer ${token}` },
   });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
 }
 
-export async function createUser(user: StoredUser): Promise<StoredUser> {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      const users = readUsers();
-      users.unshift(user);
-      writeUsers(users);
-      resolve(user);
-    }, 300);
+export async function createUser(
+  token: string,
+  data: { email: string; name: string; role: string },
+): Promise<ApiUser> {
+  const res = await fetch(`${API_BASE}/api/user`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
   });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
 }
 
-export async function updateUser(id: string, data: Partial<StoredUser>): Promise<StoredUser | null> {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      const users = readUsers();
-      const index = users.findIndex(u => u.id === id);
-      if (index === -1) {
-        resolve(null);
-        return;
-      }
-      users[index] = { ...users[index], ...data };
-      writeUsers(users);
-      resolve(users[index]);
-    }, 300);
+export async function updateUser(
+  token: string,
+  id: string,
+  data: Partial<{ name: string; role: string; status: string }>,
+): Promise<ApiUser> {
+  const res = await fetch(`${API_BASE}/api/user/${id}`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
   });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
 }
 
-export async function removeUser(id: string): Promise<void> {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      const users = readUsers().filter(u => u.id !== id);
-      writeUsers(users);
-      resolve();
-    }, 300);
+export async function removeUser(token: string, id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/user/${id}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
   });
+  if (!res.ok) throw new Error(await res.text());
 }


### PR DESCRIPTION
## Summary
- expand `User` model with role, status, and last login fields
- include role claim in issued JWTs
- track last login on login
- expose admin-only `UsersController` for managing users
- update signup/login to return new fields

## Testing
- `npm test` *(fails: Missing script)*
- `dotnet test` *(no tests found)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_b_687b18dad040832cb1001b091499d8da