### PR TITLE
Add React Router support

### DIFF
--- a/server/Controllers/UsersController.cs
+++ b/server/Controllers/UsersController.cs
@@ -56,6 +56,8 @@ namespace VaultBackend.Controllers
             var user = await _db.Users.FindAsync(id);
             if (user == null) return NotFound();
 
+            if (!string.IsNullOrEmpty(request.Name)) user.Name = request.Name;
+            if (!string.IsNullOrEmpty(request.Email)) user.Email = request.Email;
             if (!string.IsNullOrEmpty(request.Role)) user.Role = request.Role;
             if (!string.IsNullOrEmpty(request.Status)) user.Status = request.Status;
 
@@ -74,6 +76,6 @@ namespace VaultBackend.Controllers
         }
     }
 
-    public record UpdateUserRequest(string? Role, string? Status);
+    public record UpdateUserRequest(string? Name, string? Email, string? Role, string? Status);
     public record InviteUserRequest(string Email, string Name, string Role);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { LanguageProvider } from './contexts/LanguageContext';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { Layout } from './components/Layout';
@@ -23,89 +23,61 @@ import { APIPage } from './components/pages/APIPage';
 import { BackupPage } from './components/pages/BackupPage';
 import { BlockchainPage } from './components/pages/BlockchainPage';
 import { AboutPage } from './components/pages/AboutPage';
+import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 
 function AppContent() {
   const { isAuthenticated, isLoading, user } = useAuth();
-  const [authMode, setAuthMode] = useState<'login' | 'signup' | 'forgot'>('login');
-  const [currentPage, setCurrentPage] = useState('dashboard');
+  const navigate = useNavigate();
 
   if (isLoading) {
     return <LoadingScreen message="Initializing secure connection..." />;
   }
 
   if (!isAuthenticated) {
-    switch (authMode) {
-      case 'signup':
-        return <SignupForm onSwitchToLogin={() => setAuthMode('login')} />;
-      case 'forgot':
-        return <ForgotPasswordForm onSwitchToLogin={() => setAuthMode('login')} />;
-      default:
-        return (
-          <LoginForm
-            onSwitchToSignup={() => setAuthMode('signup')}
-            onSwitchToForgotPassword={() => setAuthMode('forgot')}
-          />
-        );
-    }
+    return (
+      <Routes>
+        <Route path="/signup" element={<SignupForm onSwitchToLogin={() => navigate('/login')} />} />
+        <Route path="/forgot-password" element={<ForgotPasswordForm onSwitchToLogin={() => navigate('/login')} />} />
+        <Route path="*" element={<LoginForm onSwitchToSignup={() => navigate('/signup')} onSwitchToForgotPassword={() => navigate('/forgot-password')} />} />
+      </Routes>
+    );
   }
 
-  const renderPage = () => {
-    switch (currentPage) {
-      case 'vault':
-        return <VaultPage />;
-      case 'timeline':
-        return <TimelinePage />;
-      case 'collections':
-        return <CollectionsPage />;
-      case 'archive':
-        return <ArchivePage />;
-      case 'gallery':
-        return <GalleryPage />;
-      case 'research':
-        return <ResearchPage />;
-      case 'users':
-        return user?.role === 'admin' ? (
-          <UsersPage />
-        ) : (
-          <div className="p-6">Access denied</div>
-        );
-      case 'analytics':
-        return <AnalyticsPage />;
-      case 'settings':
-        return <SettingsPage />;
-      case 'templates':
-        return <TemplatesPage />;
-      case 'export':
-        return <ExportPage />;
-      case 'privacy':
-        return <PrivacyPage />;
-      case 'api':
-        return <APIPage />;
-      case 'backup':
-        return <BackupPage />;
-      case 'blockchain':
-        return <BlockchainPage />;
-      case 'about':
-        return <AboutPage />;
-      default:
-        return <Dashboard onPageChange={setCurrentPage} />;
-    }
-  };
-
   return (
-    <Layout currentPage={currentPage} onPageChange={setCurrentPage}>
-      {renderPage()}
+    <Layout>
+      <Routes>
+        <Route path="/" element={<Dashboard />} />
+        <Route path="/vault" element={<VaultPage />} />
+        <Route path="/timeline" element={<TimelinePage />} />
+        <Route path="/collections" element={<CollectionsPage />} />
+        <Route path="/archive" element={<ArchivePage />} />
+        <Route path="/gallery" element={<GalleryPage />} />
+        <Route path="/research" element={<ResearchPage />} />
+        <Route path="/users" element={user?.role === 'admin' ? <UsersPage /> : <div className="p-6">Access denied</div>} />
+        <Route path="/analytics" element={<AnalyticsPage />} />
+        <Route path="/settings" element={<SettingsPage />} />
+        <Route path="/templates" element={<TemplatesPage />} />
+        <Route path="/export" element={<ExportPage />} />
+        <Route path="/privacy" element={<PrivacyPage />} />
+        <Route path="/api" element={<APIPage />} />
+        <Route path="/backup" element={<BackupPage />} />
+        <Route path="/blockchain" element={<BlockchainPage />} />
+        <Route path="/about" element={<AboutPage />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
     </Layout>
   );
 }
 
 function App() {
   return (
-    <LanguageProvider>
-      <AuthProvider>
-        <AppContent />
-      </AuthProvider>
-    </LanguageProvider>
+    <BrowserRouter>
+      <LanguageProvider>
+        <AuthProvider>
+          <AppContent />
+        </AuthProvider>
+      </LanguageProvider>
+    </BrowserRouter>
   );
 }
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -57,14 +57,13 @@ function getActivityIcon(type: string) {
   }
 }
 
-interface DashboardProps {
-  onPageChange: (page: string) => void;
-}
+import { useNavigate } from 'react-router-dom';
 
-export function Dashboard({ onPageChange }: DashboardProps) {
+export function Dashboard() {
   const { t } = useLanguage();
   const { user } = useAuth();
   const [showUploadModal, setShowUploadModal] = useState(false);
+  const navigate = useNavigate();
 
   const handleQuickAction = (actionName: string) => {
     switch (actionName) {
@@ -72,13 +71,13 @@ export function Dashboard({ onPageChange }: DashboardProps) {
         setShowUploadModal(true);
         break;
       case 'Create Timeline':
-        onPageChange('timeline');
+        navigate('/timeline');
         break;
       case 'New Collection':
-        onPageChange('collections');
+        navigate('/collections');
         break;
       case 'Archive Content':
-        onPageChange('archive');
+        navigate('/archive');
         break;
       default:
         break;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -18,6 +18,26 @@ export function Header({ onToggleSidebar }: HeaderProps) {
   const [showProfileDropdown, setShowProfileDropdown] = useState(false);
   const [showNotifications, setShowNotifications] = useState(false);
   const [showNewProject, setShowNewProject] = useState(false);
+  const [avatar, setAvatar] = useState<string>(user?.avatar || '');
+
+  useEffect(() => {
+    try {
+      const settings = JSON.parse(localStorage.getItem('vault_settings') || '{}');
+      setAvatar(settings.profile?.avatar || user?.avatar || '');
+    } catch {
+      setAvatar(user?.avatar || '');
+    }
+    const handler = () => {
+      try {
+        const settings = JSON.parse(localStorage.getItem('vault_settings') || '{}');
+        setAvatar(settings.profile?.avatar || user?.avatar || '');
+      } catch {
+        setAvatar(user?.avatar || '');
+      }
+    };
+    window.addEventListener('vault_settings_updated', handler);
+    return () => window.removeEventListener('vault_settings_updated', handler);
+  }, [user]);
   const [searchTerm, setSearchTerm] = useState('');
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [notifications, setNotifications] = useState(() => {
@@ -206,8 +226,8 @@ export function Header({ onToggleSidebar }: HeaderProps) {
           >
             <span className="sr-only">Open user menu</span>
             <div className="h-10 w-10 rounded-full bg-gradient-to-br from-orange-400 to-rose-500 flex items-center justify-center shadow-lg border-2 border-white/60">
-              {user?.avatar ? (
-                <img src={user.avatar} alt={user.name} className="h-10 w-10 rounded-full object-cover" />
+              {avatar ? (
+                <img src={avatar} alt={user?.name} className="h-10 w-10 rounded-full object-cover" />
               ) : (
                 <span className="text-sm font-bold text-white">
                   {user?.name?.split(' ').map(n => n[0]).join('').toUpperCase() || 'U'}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,14 +22,16 @@ export function Header({ onToggleSidebar }: HeaderProps) {
 
   useEffect(() => {
     try {
-      const settings = JSON.parse(localStorage.getItem('vault_settings') || '{}');
+      const key = user ? `vault_settings_${user.id}` : 'vault_settings';
+      const settings = JSON.parse(localStorage.getItem(key) || '{}');
       setAvatar(settings.profile?.avatar || user?.avatar || '');
     } catch {
       setAvatar(user?.avatar || '');
     }
     const handler = () => {
       try {
-        const settings = JSON.parse(localStorage.getItem('vault_settings') || '{}');
+        const key = user ? `vault_settings_${user.id}` : 'vault_settings';
+        const settings = JSON.parse(localStorage.getItem(key) || '{}');
         setAvatar(settings.profile?.avatar || user?.avatar || '');
       } catch {
         setAvatar(user?.avatar || '');

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,15 +5,16 @@ import { useAuth } from '../contexts/AuthContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import { NewProjectModal } from './NewProjectModal';
 import { ProfileDropdown } from './ProfileDropdown';
+import { useNavigate } from 'react-router-dom';
 
 interface HeaderProps {
   onToggleSidebar: () => void;
-  onNavigate?: (page: string) => void;
 }
 
-export function Header({ onToggleSidebar, onNavigate }: HeaderProps) {
+export function Header({ onToggleSidebar }: HeaderProps) {
   const { user, logout } = useAuth();
   const { t } = useLanguage();
+  const navigate = useNavigate();
   const [showProfileDropdown, setShowProfileDropdown] = useState(false);
   const [showNotifications, setShowNotifications] = useState(false);
   const [showNewProject, setShowNewProject] = useState(false);
@@ -60,7 +61,7 @@ export function Header({ onToggleSidebar, onNavigate }: HeaderProps) {
   const handleSelect = (page: string) => {
     setSearchTerm('');
     setShowSuggestions(false);
-    onNavigate?.(page);
+    navigate(`/${page}`);
   };
 
   const markAsRead = (id: number) => {
@@ -226,7 +227,6 @@ export function Header({ onToggleSidebar, onNavigate }: HeaderProps) {
             logout={logout}
             show={showProfileDropdown}
             onClose={() => setShowProfileDropdown(false)}
-            onNavigate={onNavigate}
           />
         </div>
       </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,26 +6,19 @@ import { Footer } from './Footer';
 
 interface LayoutProps {
   children: React.ReactNode;
-  currentPage: string;
-  onPageChange: (page: string) => void;
 }
 
-export function Layout({ children, currentPage, onPageChange }: LayoutProps) {
+export function Layout({ children }: LayoutProps) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-primary-50 via-white to-purple-50">
-      <Navigation 
-        currentPage={currentPage} 
-        onPageChange={onPageChange}
+      <Navigation
         collapsed={sidebarCollapsed}
         onToggleCollapse={() => setSidebarCollapsed(!sidebarCollapsed)}
       />
       <div className={`transition-all duration-300 ${sidebarCollapsed ? 'lg:pl-20' : 'lg:pl-72'}`}>
-        <Header
-          onToggleSidebar={() => setSidebarCollapsed(!sidebarCollapsed)}
-          onNavigate={onPageChange}
-        />
+        <Header onToggleSidebar={() => setSidebarCollapsed(!sidebarCollapsed)} />
         <main className="py-8">
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             {children}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -22,34 +22,34 @@ import {
   Info
 } from 'lucide-react';
 
+import { NavLink } from 'react-router-dom';
+
 interface NavigationProps {
-  currentPage: string;
-  onPageChange: (page: string) => void;
   collapsed: boolean;
   onToggleCollapse: () => void;
 }
 
-export function Navigation({ currentPage, onPageChange, collapsed, onToggleCollapse }: NavigationProps) {
+export function Navigation({ collapsed, onToggleCollapse }: NavigationProps) {
   const { logout, user } = useAuth();
   const { t, currentLanguage, languages, changeLanguage } = useLanguage();
   const [showLanguageDropdown, setShowLanguageDropdown] = useState(false);
 
   const navigation = [
-    { name: t('dashboard'), page: 'dashboard', icon: LayoutDashboard },
-    { name: t('vault'), page: 'vault', icon: Vault },
-    { name: t('timeline'), page: 'timeline', icon: Clock },
-    { name: t('collections'), page: 'collections', icon: FolderOpen },
-    { name: t('archive'), page: 'archive', icon: Archive },
-    { name: t('gallery'), page: 'gallery', icon: ImageIcon },
-    { name: t('research'), page: 'research', icon: Search },
-    ...(user?.role === 'admin' ? [{ name: t('users'), page: 'users', icon: Users }] : []),
-    { name: t('analytics'), page: 'analytics', icon: BarChart3 },
-    { name: 'API', page: 'api', icon: Key },
-    { name: 'Blockchain', page: 'blockchain', icon: Vault },
-    { name: t('settings'), page: 'settings', icon: Settings },
-    { name: t('templates'), page: 'templates', icon: FileText },
-    { name: t('export'), page: 'export', icon: Download },
-    { name: t('about'), page: 'about', icon: Info },
+    { name: t('dashboard'), to: '/', icon: LayoutDashboard },
+    { name: t('vault'), to: '/vault', icon: Vault },
+    { name: t('timeline'), to: '/timeline', icon: Clock },
+    { name: t('collections'), to: '/collections', icon: FolderOpen },
+    { name: t('archive'), to: '/archive', icon: Archive },
+    { name: t('gallery'), to: '/gallery', icon: ImageIcon },
+    { name: t('research'), to: '/research', icon: Search },
+    ...(user?.role === 'admin' ? [{ name: t('users'), to: '/users', icon: Users }] : []),
+    { name: t('analytics'), to: '/analytics', icon: BarChart3 },
+    { name: 'API', to: '/api', icon: Key },
+    { name: 'Blockchain', to: '/blockchain', icon: Vault },
+    { name: t('settings'), to: '/settings', icon: Settings },
+    { name: t('templates'), to: '/templates', icon: FileText },
+    { name: t('export'), to: '/export', icon: Download },
+    { name: t('about'), to: '/about', icon: Info },
   ];
 
 function classNames(...classes: string[]) {
@@ -88,26 +88,32 @@ function classNames(...classes: string[]) {
               <ul role="list" className="-mx-2 space-y-1">
                 {navigation.map((item) => (
                   <li key={item.name}>
-                    <button
-                      onClick={() => onPageChange(item.page)}
-                      className={classNames(
-                        currentPage === item.page
-                          ? 'bg-white/20 text-white border-r-4 border-orange-400 shadow-lg'
-                          : 'text-white/80 hover:text-white hover:bg-white/10',
-                        `group flex gap-x-3 rounded-l-xl p-3 text-sm leading-6 font-medium transition-all duration-300 w-full text-left hover:shadow-lg ${collapsed ? 'justify-center' : ''}`
-                      )}
+                    <NavLink
+                      to={item.to}
+                      className={({ isActive }) =>
+                        classNames(
+                          isActive
+                            ? 'bg-white/20 text-white border-r-4 border-orange-400 shadow-lg'
+                            : 'text-white/80 hover:text-white hover:bg-white/10',
+                          `group flex gap-x-3 rounded-l-xl p-3 text-sm leading-6 font-medium transition-all duration-300 w-full text-left hover:shadow-lg ${collapsed ? 'justify-center' : ''}`
+                        )
+                      }
                     >
-                      <item.icon
-                        className={classNames(
-                          currentPage === item.page ? 'text-orange-400' : 'text-white/60 group-hover:text-white',
-                          'h-5 w-5 shrink-0'
-                        )}
-                        aria-hidden="true"
-                      />
-                      {!collapsed && (
-                        <span className="transition-opacity duration-300">{item.name}</span>
+                      {({ isActive }) => (
+                        <>
+                          <item.icon
+                            className={classNames(
+                              isActive ? 'text-orange-400' : 'text-white/60 group-hover:text-white',
+                              'h-5 w-5 shrink-0'
+                            )}
+                            aria-hidden="true"
+                          />
+                          {!collapsed && (
+                            <span className="transition-opacity duration-300">{item.name}</span>
+                          )}
+                        </>
                       )}
-                    </button>
+                    </NavLink>
                   </li>
                 ))}
               </ul>

--- a/src/components/ProfileDropdown.tsx
+++ b/src/components/ProfileDropdown.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { User, Settings, LogOut } from 'lucide-react';
 import { User as UserType } from '../types';
+import { useNavigate } from 'react-router-dom';
 
 interface ProfileDropdownProps {
   user: UserType | null;
@@ -8,11 +9,11 @@ interface ProfileDropdownProps {
   logout: () => void;
   show: boolean;
   onClose: () => void;
-  onNavigate?: (page: string) => void;
 }
 
-export function ProfileDropdown({ user, t, logout, show, onClose, onNavigate }: ProfileDropdownProps) {
+export function ProfileDropdown({ user, t, logout, show, onClose }: ProfileDropdownProps) {
   const ref = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {
@@ -52,7 +53,7 @@ export function ProfileDropdown({ user, t, logout, show, onClose, onNavigate }: 
         <button
           className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-primary-50/60 rounded-xl"
           onClick={() => {
-            onNavigate?.('profile');
+            navigate('/profile');
             onClose();
           }}
         >
@@ -62,7 +63,7 @@ export function ProfileDropdown({ user, t, logout, show, onClose, onNavigate }: 
         <button
           className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-primary-50/60 rounded-xl"
           onClick={() => {
-            onNavigate?.('settings');
+            navigate('/settings');
             onClose();
           }}
         >

--- a/src/components/ProfileDropdown.tsx
+++ b/src/components/ProfileDropdown.tsx
@@ -32,10 +32,23 @@ export function ProfileDropdown({ user, t, logout, show, onClose }: ProfileDropd
 
   return (
     <div ref={ref} className="absolute right-0 mt-2 w-56 bg-white/90 rounded-2xl shadow-2xl border border-gray-200 py-2 z-50 backdrop-blur-xl">
-      <div className="px-4 py-3 border-b border-gray-200">
-        <p className="text-sm font-bold text-gray-900">{user?.name || 'User'}</p>
-        <p className="text-sm text-gray-600">{user?.email || 'user@example.com'}</p>
-        <div className="flex items-center gap-1 mt-1">
+      <div className="px-4 pt-3 pb-2 border-b border-gray-200 flex items-center space-x-3">
+        <div className="h-10 w-10 rounded-full bg-gradient-to-br from-orange-400 to-rose-500 flex items-center justify-center shadow-lg">
+          {user?.avatar ? (
+            <img src={user.avatar} alt={user.name} className="h-10 w-10 rounded-full object-cover" />
+          ) : (
+            <span className="text-sm font-bold text-white">
+              {user?.name?.split(' ').map(n => n[0]).join('').toUpperCase() || 'U'}
+            </span>
+          )}
+        </div>
+        <div>
+          <p className="text-sm font-bold text-gray-900">{user?.name || 'User'}</p>
+          <p className="text-sm text-gray-600">{user?.email || 'user@example.com'}</p>
+        </div>
+      </div>
+      <div className="px-4 mt-2">
+        <div className="flex items-center gap-1">
           <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
             {user?.role || 'User'}
           </span>

--- a/src/components/pages/AnalyticsPage.tsx
+++ b/src/components/pages/AnalyticsPage.tsx
@@ -36,35 +36,6 @@ interface AnalyticsData {
   geographicData: { country: string; visitors: number; percentage: number }[];
 }
 
-const generateTimeSeriesData = (days: number) => {
-  const data = [] as AnalyticsData['timeSeriesData'];
-  for (let i = days - 1; i >= 0; i--) {
-    const d = new Date();
-    d.setDate(d.getDate() - i);
-    data.push({
-      date: d.toISOString().slice(0, 10),
-      views: Math.floor(Math.random() * 1000) + 500,
-      visitors: Math.floor(Math.random() * 500) + 200,
-      sessions: Math.floor(Math.random() * 400) + 150,
-    });
-  }
-  return data;
-};
-
-const generateDeviceData = (): AnalyticsData['deviceData'] => {
-  const desktop = Math.floor(Math.random() * 30) + 40;
-  const mobile = Math.floor(Math.random() * (100 - desktop - 10)) + 10;
-  const tablet = 100 - desktop - mobile;
-  return [
-    { name: 'Desktop', value: desktop, color: '#3B82F6' },
-    { name: 'Mobile', value: mobile, color: '#10B981' },
-    { name: 'Tablet', value: tablet, color: '#F59E0B' },
-  ];
-};
-
-
-
-const randomTrend = () => Number((Math.random() * 20 - 10).toFixed(1));
 
 const getDaysForRange = (range: string) => {
   switch (range) {
@@ -79,19 +50,22 @@ const getDaysForRange = (range: string) => {
   }
 };
 
-const generateAnalyticsData = (_days: number): AnalyticsData => ({
-  overview: {
-    totalViews: 0,
-    uniqueVisitors: 0,
-    avgSessionDuration: "0:00",
-    bounceRate: "0%",
-    trends: { views: 0, visitors: 0, duration: 0, bounce: 0 },
-  },
-  timeSeriesData: [],
-  deviceData: [],
-  topContent: [],
-  geographicData: [],
-});
+const generateAnalyticsData = (days: number): AnalyticsData => {
+  void days;
+  return {
+    overview: {
+      totalViews: 0,
+      uniqueVisitors: 0,
+      avgSessionDuration: '0:00',
+      bounceRate: '0%',
+      trends: { views: 0, visitors: 0, duration: 0, bounce: 0 },
+    },
+    timeSeriesData: [],
+    deviceData: [],
+    topContent: [],
+    geographicData: [],
+  };
+};
 
 export function AnalyticsPage() {
   const [dateRange, setDateRange] = useState('7d');

--- a/src/components/pages/ExportPage.tsx
+++ b/src/components/pages/ExportPage.tsx
@@ -110,7 +110,7 @@ export function ExportPage() {
   const [newName, setNewName] = useState('');
   const [format, setFormat] = useState('zip');
   const [source, setSource] = useState<'vault' | 'gallery'>('vault');
-  const [vaultStructure, setVaultStructure] = useState<VaultItem[]>(() => {
+  const [vaultStructure] = useState<VaultItem[]>(() => {
     const stored = localStorage.getItem('vault_files');
     return stored ? JSON.parse(stored) : [];
   });
@@ -120,17 +120,32 @@ export function ExportPage() {
     id: string;
     title: string;
   }
-  const [galleryItems, setGalleryItems] = useState<GalleryItem[]>(() => {
+  const [galleryItems] = useState<GalleryItem[]>(() => {
     const stored = localStorage.getItem('gallery_items');
     if (!stored) return [];
     try { return JSON.parse(stored); } catch { return []; }
   });
   const [gallerySelected, setGallerySelected] = useState<string[]>([]);
+  interface ExportItem {
+    id: string;
+    name: string;
+    format: string;
+    status: string;
+    created: string;
+    size: string;
+    downloadCount: number;
+    includes: string[];
+    source?: 'vault' | 'gallery';
+    path?: string[];
+    items: string[];
+    itemNames?: string[];
+    expires?: string;
+  }
   const [alert, setAlert] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
-  const [detailsExport, setDetailsExport] = useState<any | null>(null);
+  const [detailsExport, setDetailsExport] = useState<ExportItem | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
-  const [exportsList, setExportsList] = useState(() => {
+  const [exportsList, setExportsList] = useState<ExportItem[]>(() => {
     const stored = localStorage.getItem('exports');
     return stored ? JSON.parse(stored) : [];
   });
@@ -202,7 +217,7 @@ export function ExportPage() {
     URL.revokeObjectURL(url);
   };
 
-  const shareExport = async (item: any) => {
+  const shareExport = async (item: ExportItem) => {
     const url = `${window.location.origin}?export=${item.id}`;
     try {
       if (navigator.share) {

--- a/src/components/pages/ResearchPage.tsx
+++ b/src/components/pages/ResearchPage.tsx
@@ -59,14 +59,15 @@ export function ResearchPage() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [researchItems, setResearchItems] = useState<ResearchItem[]>(() => {
     const stored = localStorage.getItem('research_items');
-    const items = stored ? JSON.parse(stored) : [];
-    return items.map((it: any) => {
-      const attachments = Array.isArray(it.attachments)
-        ? it.attachments.map((att: any) =>
-            typeof att === 'string' ? { name: att, url: '' } : att
+    const items: unknown[] = stored ? JSON.parse(stored) : [];
+    return items.map((raw) => {
+      const it = raw as Partial<ResearchItem> & { attachments?: unknown[] };
+      const attachments: ResearchAttachment[] = Array.isArray(it.attachments)
+        ? it.attachments.map((att) =>
+            typeof att === 'string' ? { name: att, url: '' } : (att as ResearchAttachment)
           )
         : [];
-      return { ...it, attachments } as ResearchItem;
+      return { ...(it as ResearchItem), attachments };
     });
   });
   const [form, setForm] = useState({

--- a/src/components/pages/SettingsPage.tsx
+++ b/src/components/pages/SettingsPage.tsx
@@ -97,6 +97,7 @@ export function SettingsPage() {
     setTimeout(() => {
       localStorage.setItem('vault_settings', JSON.stringify(settings));
       localStorage.setItem('vault_api_keys', JSON.stringify(apiKeys));
+      window.dispatchEvent(new Event('vault_settings_updated'));
       setIsSaving(false);
       setAlert({ message: 'Settings saved', type: 'success' });
     }, 800);
@@ -195,7 +196,7 @@ export function SettingsPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ enable: !settings.security.twoFactorEnabled }),
       });
-    } catch (e) {
+    } catch {
       // ignore network errors in offline demo
     }
     setSettings(prev => ({
@@ -210,7 +211,7 @@ export function SettingsPage() {
     setSessionLoading(id);
     try {
       await fetch(`/api/sessions/${id}`, { method: 'DELETE' });
-    } catch (e) {
+    } catch {
       // ignore network errors
     }
     setSessions(prev => prev.filter(s => s.id !== id));
@@ -222,7 +223,9 @@ export function SettingsPage() {
     setSessionLoading('all');
     try {
       await fetch('/api/sessions', { method: 'DELETE' });
-    } catch (e) {}
+    } catch {
+      // ignore errors
+    }
     setSessions([{ id: 'current', device: 'This Device', ip: '127.0.0.1', lastActive: new Date().toISOString() }]);
     setSessionLoading(null);
     setAlert({ message: 'Other sessions revoked', type: 'success' });
@@ -236,7 +239,9 @@ export function SettingsPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ [key]: !settings.notifications[key as keyof typeof settings.notifications] }),
       });
-    } catch (e) {}
+    } catch {
+      // ignore errors
+    }
     setSettings(prev => ({
       ...prev,
       notifications: {

--- a/src/components/pages/SettingsPage.tsx
+++ b/src/components/pages/SettingsPage.tsx
@@ -61,22 +61,22 @@ export function SettingsPage() {
     data: { storageUsed: 0, storageLimit: 100, autoBackup: false, compressionEnabled: false, retentionPeriod: 0 },
     privacy: { profileVisibility: "private", searchEngineIndexing: false, analyticsTracking: false, dataSharing: false }
   };
-  const [settings, setSettings] = useState(() => {
-    const stored = localStorage.getItem('vault_settings');
-    return stored ? JSON.parse(stored) : defaultSettings;
-  });
+  const [settings, setSettings] = useState(() => defaultSettings);
 
   useEffect(() => {
     if (!user) return;
-    setSettings((prev) => ({
-      ...prev,
-      profile: {
-        ...prev.profile,
-        name: user.name,
-        email: user.email,
-        avatar: user.avatar || prev.profile.avatar,
+    const stored = localStorage.getItem(`vault_settings_${user.id}`);
+    setSettings(
+      stored ? JSON.parse(stored) : {
+        ...defaultSettings,
+        profile: {
+          ...defaultSettings.profile,
+          name: user.name,
+          email: user.email,
+          avatar: user.avatar || defaultSettings.profile.avatar,
+        },
       },
-    }));
+    );
   }, [user]);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -95,7 +95,9 @@ export function SettingsPage() {
   const saveSettings = () => {
     setIsSaving(true);
     setTimeout(() => {
-      localStorage.setItem('vault_settings', JSON.stringify(settings));
+      if (user) {
+        localStorage.setItem(`vault_settings_${user.id}`, JSON.stringify(settings));
+      }
       localStorage.setItem('vault_api_keys', JSON.stringify(apiKeys));
       window.dispatchEvent(new Event('vault_settings_updated'));
       setIsSaving(false);

--- a/src/components/pages/UsersPage.tsx
+++ b/src/components/pages/UsersPage.tsx
@@ -34,7 +34,7 @@ export interface UserItem {
   id: string;
   name: string;
   email: string;
-  role: "admin" | "editor" | "contributor" | "viewer";
+  role: "admin" | "user" | "contributor" | "viewer";
   status: "active" | "pending" | "inactive" | "suspended";
   lastLogin: string | null;
   createdAt: string;
@@ -51,8 +51,8 @@ const roles = [
     color: "bg-red-100 text-red-800 border-red-200",
   },
   {
-    name: "Editor",
-    value: "editor",
+    name: "User",
+    value: "user",
     description: "Can create, edit, and manage content",
     permissions: ["read", "write", "delete"],
     color: "bg-blue-100 text-blue-800 border-blue-200",
@@ -159,7 +159,7 @@ export function UsersPage() {
     switch (role) {
       case "admin":
         return Crown;
-      case "editor":
+      case "user":
         return Edit;
       case "contributor":
         return UserPlus;
@@ -230,6 +230,8 @@ export function UsersPage() {
     try {
       if (editingId) {
         const updated = await updateUser(token, editingId, {
+          name: form.name,
+          email: form.email,
           role: form.role,
           status: form.status,
         });
@@ -237,10 +239,12 @@ export function UsersPage() {
           prev.map((u) =>
             u.id === editingId
               ? {
-                  ...u,
-                  role: updated.role,
-                  status: updated.status,
-                }
+                ...u,
+                name: updated.name,
+                email: updated.email,
+                role: updated.role,
+                status: updated.status,
+              }
               : u,
           ),
         );
@@ -283,7 +287,7 @@ export function UsersPage() {
 
   const bulkChangeRole = async () => {
     const role = prompt(
-      "Enter new role (admin, editor, contributor, viewer):",
+      "Enter new role (admin, user, contributor, viewer):",
       "viewer",
     );
     if (!role) return;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -50,7 +50,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
           const decrypted = JSON.parse(
             EncryptionService.decrypt(encryptedUser),
           );
-          const userData = { status: "active", ...decrypted } as User;
+          let avatar: string | undefined;
+          try {
+            const settings = JSON.parse(localStorage.getItem("vault_settings") || "{}");
+            avatar = settings.profile?.avatar;
+          } catch {
+            avatar = undefined;
+          }
+          const userData = { status: "active", avatar, ...decrypted } as User;
           setAuthState({
             user: userData,
             isAuthenticated: true,
@@ -105,6 +112,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
         status: data.status as User["status"],
         createdAt: new Date(data.createdAt),
         lastLogin: data.lastLogin ? new Date(data.lastLogin) : undefined,
+        avatar: (() => {
+          try {
+            const settings = JSON.parse(localStorage.getItem("vault_settings") || "{}");
+            return settings.profile?.avatar;
+          } catch {
+            return undefined;
+          }
+        })(),
       };
 
       localStorage.setItem("vault_token", data.token);
@@ -170,6 +185,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
         status: data.status as User["status"],
         createdAt: new Date(data.createdAt),
         lastLogin: data.lastLogin ? new Date(data.lastLogin) : undefined,
+        avatar: (() => {
+          try {
+            const settings = JSON.parse(localStorage.getItem("vault_settings") || "{}");
+            return settings.profile?.avatar;
+          } catch {
+            return undefined;
+          }
+        })(),
       };
 
       localStorage.setItem("vault_token", data.token);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -52,7 +52,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
           );
           let avatar: string | undefined;
           try {
-            const settings = JSON.parse(localStorage.getItem("vault_settings") || "{}");
+            const key = `vault_settings_${decrypted.id}`;
+            const settings = JSON.parse(localStorage.getItem(key) || "{}");
             avatar = settings.profile?.avatar;
           } catch {
             avatar = undefined;
@@ -80,6 +81,24 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
     checkAuth();
   }, []);
+
+  useEffect(() => {
+    if (!authState.user) return;
+    const handler = () => {
+      try {
+        const key = `vault_settings_${authState.user?.id}`;
+        const settings = JSON.parse(localStorage.getItem(key) || '{}');
+        setAuthState(prev => ({
+          ...prev,
+          user: prev.user ? { ...prev.user, avatar: settings.profile?.avatar } : null,
+        }));
+      } catch {
+        // ignore parse errors
+      }
+    };
+    window.addEventListener('vault_settings_updated', handler);
+    return () => window.removeEventListener('vault_settings_updated', handler);
+  }, [authState.user]);
 
   const login = async (email: string, password: string): Promise<void> => {
     setAuthState((prev) => ({ ...prev, isLoading: true, error: null }));
@@ -114,7 +133,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
         lastLogin: data.lastLogin ? new Date(data.lastLogin) : undefined,
         avatar: (() => {
           try {
-            const settings = JSON.parse(localStorage.getItem("vault_settings") || "{}");
+            const key = `vault_settings_${data.id}`;
+            const settings = JSON.parse(localStorage.getItem(key) || "{}");
             return settings.profile?.avatar;
           } catch {
             return undefined;
@@ -187,7 +207,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
         lastLogin: data.lastLogin ? new Date(data.lastLogin) : undefined,
         avatar: (() => {
           try {
-            const settings = JSON.parse(localStorage.getItem("vault_settings") || "{}");
+            const key = `vault_settings_${data.id}`;
+            const settings = JSON.parse(localStorage.getItem(key) || "{}");
             return settings.profile?.avatar;
           } catch {
             return undefined;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@ export interface User {
   id: string;
   email: string;
   name: string;
-  role: 'admin' | 'editor' | 'viewer';
+  role: 'admin' | 'user' | 'viewer';
   status: 'active' | 'pending' | 'inactive' | 'suspended';
   avatar?: string;
   createdAt: Date;

--- a/src/utils/users.ts
+++ b/src/utils/users.ts
@@ -2,7 +2,7 @@ export interface ApiUser {
   id: string;
   email: string;
   name: string;
-  role: "admin" | "editor" | "contributor" | "viewer";
+  role: "admin" | "user" | "contributor" | "viewer";
   status: "active" | "pending" | "inactive" | "suspended";
   createdAt: string;
   lastLogin: string | null;
@@ -37,7 +37,7 @@ export async function createUser(
 export async function updateUser(
   token: string,
   id: string,
-  data: Partial<{ role: string; status: string }>,
+  data: Partial<{ name: string; email: string; role: string; status: string }>,
 ): Promise<ApiUser> {
   const res = await fetch(`${API_BASE}/api/user/${id}`, {
     method: "PATCH",


### PR DESCRIPTION
## Summary
- switch to `BrowserRouter` and create routes for each page
- update dashboard and navigation to use `useNavigate`/`NavLink`
- remove page switching props in layout and header
- handle navigation from profile dropdown

## Testing
- `npm run lint` *(fails: 16 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687be233eaac832bb36b8ad6b2f2921c