### PR TITLE
Fix activity duplication and view link

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -62,6 +62,17 @@ export function Dashboard() {
   const connectionRef = useRef<HubConnection | null>(null);
   const navigate = useNavigate();
 
+  const handleView = (activity: ActivityLog) => {
+    const action = activity.action.toLowerCase();
+    if (action.includes('vault') || action.includes('file')) {
+      navigate('/vault');
+    } else if (action.includes('profile') || action.includes('password')) {
+      navigate('/settings');
+    } else if (action.includes('chat')) {
+      navigate('/research');
+    }
+  };
+
   useEffect(() => {
     if (!token) return;
     getRecentActivity(token).then(setRecent).catch(console.error);
@@ -270,7 +281,7 @@ export function Dashboard() {
                         <p className="text-xs sm:text-sm text-gray-600">{new Date(activity.timestamp).toLocaleString()}</p>
                       </div>
                       <div className="flex-shrink-0 flex items-center justify-end">
-                        <button className="text-xs sm:text-sm text-primary-600 hover:text-primary-800 font-semibold px-2 sm:px-3 py-1 rounded-lg hover:bg-primary-50 transition-all duration-200">
+                        <button onClick={() => handleView(activity)} className="text-xs sm:text-sm text-primary-600 hover:text-primary-800 font-semibold px-2 sm:px-3 py-1 rounded-lg hover:bg-primary-50 transition-all duration-200">
                           View
                         </button>
                       </div>

--- a/src/components/pages/VaultPage.tsx
+++ b/src/components/pages/VaultPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { FolderPlus, Upload } from 'lucide-react';
 import { FileManager, VaultItem } from '../FileManager';
 import { useAuth } from '../../contexts/AuthContext';
@@ -8,6 +8,7 @@ export function VaultPage({ initialPath = [] }: { initialPath?: string[] }) {
   const { isAuthenticated, token } = useAuth();
 
   const [structure, setStructure] = useState<VaultItem[]>([]);
+  const loadedRef = useRef(false);
 
   useEffect(() => {
     if (!isAuthenticated) return;
@@ -15,6 +16,7 @@ export function VaultPage({ initialPath = [] }: { initialPath?: string[] }) {
       try {
         const data = await fetchVaultStructure(token);
         setStructure(data);
+        loadedRef.current = true;
       } catch (e) {
         console.error(e);
       }
@@ -23,7 +25,7 @@ export function VaultPage({ initialPath = [] }: { initialPath?: string[] }) {
   }, [isAuthenticated, token]);
 
   useEffect(() => {
-    if (!isAuthenticated) return;
+    if (!isAuthenticated || !loadedRef.current) return;
     saveVaultStructure(token, structure).catch(console.error);
   }, [structure, isAuthenticated, token]);
 


### PR DESCRIPTION
## Summary
- prevent saving vault structure right after fetch
- add navigation from recent activity entries

## Testing
- `npm run lint`
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687ca1ca20a88324beee05806aaddb0c