### PR TITLE
Remove localStorage dependencies

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useUserData } from '../utils/userData';
 import { ThemeToggle } from './ThemeToggle';
 import { Bell, Search, Plus, Menu, ChevronDown } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
@@ -21,40 +22,20 @@ export function Header({ onToggleSidebar }: HeaderProps) {
   const [avatar, setAvatar] = useState<string>(user?.avatar || '');
 
   useEffect(() => {
-    try {
-      const key = user ? `vault_settings_${user.id}` : 'vault_settings';
-      const settings = JSON.parse(localStorage.getItem(key) || '{}');
-      setAvatar(settings.profile?.avatar || user?.avatar || '');
-    } catch {
-      setAvatar(user?.avatar || '');
-    }
-    const handler = () => {
-      try {
-        const key = user ? `vault_settings_${user.id}` : 'vault_settings';
-        const settings = JSON.parse(localStorage.getItem(key) || '{}');
-        setAvatar(settings.profile?.avatar || user?.avatar || '');
-      } catch {
-        setAvatar(user?.avatar || '');
-      }
-    };
+    setAvatar(user?.avatar || '');
+    const handler = () => setAvatar(user?.avatar || '');
     window.addEventListener('vault_settings_updated', handler);
     return () => window.removeEventListener('vault_settings_updated', handler);
   }, [user]);
   const [searchTerm, setSearchTerm] = useState('');
   const [showSuggestions, setShowSuggestions] = useState(false);
-  const [notifications, setNotifications] = useState(() => {
-    const stored = localStorage.getItem('vault_notifications');
-    if (stored) return JSON.parse(stored);
-    return [
-      { id: 1, title: 'New collection shared', message: 'Sarah shared "Wedding Photos" with you', time: '2 min ago', unread: true },
-      { id: 2, title: 'Archive completed', message: 'Family Documents archive has been processed', time: '1 hour ago', unread: true },
-      { id: 3, title: 'Timeline updated', message: 'New milestone added to "Life Journey"', time: '3 hours ago', unread: false },
-    ];
-  });
+  const [notifications, setNotifications] = useUserData('notifications', [
+    { id: 1, title: 'New collection shared', message: 'Sarah shared "Wedding Photos" with you', time: '2 min ago', unread: true },
+    { id: 2, title: 'Archive completed', message: 'Family Documents archive has been processed', time: '1 hour ago', unread: true },
+    { id: 3, title: 'Timeline updated', message: 'New milestone added to "Life Journey"', time: '3 hours ago', unread: false },
+  ]);
 
-  useEffect(() => {
-    localStorage.setItem('vault_notifications', JSON.stringify(notifications));
-  }, [notifications]);
+  // persistence handled by useUserData
 
   const unreadCount = notifications.filter(n => n.unread).length;
 
@@ -98,11 +79,10 @@ export function Header({ onToggleSidebar }: HeaderProps) {
     setNotifications([]);
   };
 
+  const [projects, setProjects] = useUserData('projects', [] as Array<{ id: number; name: string; description: string }>);
+
   const handleCreateProject = (project: { name: string; description: string }) => {
-    const stored = localStorage.getItem('vault_projects');
-    const projects = stored ? JSON.parse(stored) : [];
-    projects.push({ id: Date.now(), ...project });
-    localStorage.setItem('vault_projects', JSON.stringify(projects));
+    setProjects(prev => [...prev, { id: Date.now(), ...project }]);
   };
 
   return (

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,39 +1,26 @@
 import React, { useEffect, useState } from 'react';
+import { useUserData } from '../utils/userData';
 
 
 export function ThemeToggle() {
   const getSystemPref = () =>
     window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const getInitial = () => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('theme');
-      if (saved === 'dark') return true;
-      if (saved === 'light') return false;
-      return getSystemPref();
-    }
-    return false;
-  };
-  const [dark, setDark] = useState(getInitial);
+  const [dark, setDark] = useUserData('theme', getSystemPref());
 
   useEffect(() => {
     if (dark) {
       document.documentElement.classList.add('dark');
-      localStorage.setItem('theme', 'dark');
     } else {
       document.documentElement.classList.remove('dark');
-      localStorage.setItem('theme', 'light');
     }
   }, [dark]);
 
   useEffect(() => {
-    const saved = localStorage.getItem('theme');
-    if (!saved) {
-      setDark(getSystemPref());
-    }
+    setDark(getSystemPref());
     // Listen for system changes if no manual override
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
     const handler = (e: MediaQueryListEvent) => {
-      if (!localStorage.getItem('theme')) setDark(e.matches);
+      setDark(e.matches);
     };
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);

--- a/src/components/pages/APIPage.tsx
+++ b/src/components/pages/APIPage.tsx
@@ -33,7 +33,7 @@ const apiEndpoints = [
 ];
 
 export function APIPage() {
-  useAuth();
+  const auth = useAuth();
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [visibleKeys, setVisibleKeys] = useState<string[]>([]);
   interface ApiKey {
@@ -73,9 +73,8 @@ export function APIPage() {
       setLoading(true);
       setError(null);
       try {
-        const token = localStorage.getItem('vault_jwt');
-        if (!token) throw new Error('Not authenticated');
-        const keys = await fetchApiKeys(token);
+        if (!auth.token) throw new Error('Not authenticated');
+        const keys = await fetchApiKeys(auth.token);
         setApiKeys(keys);
       } catch (e: unknown) {
         const message = e instanceof Error ? e.message : 'Failed to load API keys';
@@ -89,9 +88,8 @@ export function APIPage() {
 
   const handleCreateKey = async (name: string, permissions: string[]) => {
     try {
-      const token = localStorage.getItem('vault_jwt');
-      if (!token) throw new Error('Not authenticated');
-      const newKey = await createApiKey(token, name, permissions);
+      if (!auth.token) throw new Error('Not authenticated');
+      const newKey = await createApiKey(auth.token, name, permissions);
       setApiKeys(prev => [newKey, ...prev]);
       setAlert({ message: 'API key created!', type: 'success' });
     } catch (e: unknown) {
@@ -107,9 +105,8 @@ export function APIPage() {
 
   const handleRefresh = async (id: string) => {
     try {
-      const token = localStorage.getItem('vault_jwt');
-      if (!token) throw new Error('Not authenticated');
-      const updated = await regenerateApiKey(token, id);
+      if (!auth.token) throw new Error('Not authenticated');
+      const updated = await regenerateApiKey(auth.token, id);
       setApiKeys(prev => prev.map(k => k.id === id ? updated : k));
       setAlert({ message: 'API key regenerated!', type: 'success' });
     } catch (e: unknown) {
@@ -121,9 +118,8 @@ export function APIPage() {
   const handleDelete = async (id: string) => {
     if (window.confirm('Are you sure you want to revoke this API key?')) {
       try {
-        const token = localStorage.getItem('vault_jwt');
-        if (!token) throw new Error('Not authenticated');
-        await deleteApiKey(token, id);
+        if (!auth.token) throw new Error('Not authenticated');
+        await deleteApiKey(auth.token, id);
         setApiKeys(prev => prev.filter(k => k.id !== id));
         setAlert({ message: 'API key revoked!', type: 'success' });
       } catch (e: unknown) {

--- a/src/components/pages/BackupPage.tsx
+++ b/src/components/pages/BackupPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useUserData } from '../../utils/userData';
 import {
   HardDrive,
   Cloud,
@@ -26,15 +27,8 @@ export function BackupPage() {
   const [location, setLocation] = useState('cloud');
   const [alert, setAlert] = useState<string | null>(null);
 
-  const [backups, setBackups] = useState(() => {
-    const stored = localStorage.getItem('backups');
-    return stored ? JSON.parse(stored) : [];
-  });
-
-  const [schedules, setSchedules] = useState(() => {
-    const stored = localStorage.getItem('backup_schedules');
-    return stored ? JSON.parse(stored) : [];
-  });
+  const [backups, setBackups] = useUserData('backups', []);
+  const [schedules, setSchedules] = useUserData('backup_schedules', []);
   const [backupSettings, setBackupSettings] = useState({
     autoBackup: true,
     cloudSync: true,
@@ -44,13 +38,7 @@ export function BackupPage() {
     maxBackups: 10,
   });
 
-  useEffect(() => {
-    localStorage.setItem('backups', JSON.stringify(backups));
-  }, [backups]);
-
-  useEffect(() => {
-    localStorage.setItem('backup_schedules', JSON.stringify(schedules));
-  }, [schedules]);
+  // persistence handled by useUserData
 
   useEffect(() => {
     if (!alert) return;
@@ -193,7 +181,6 @@ export function BackupPage() {
                   onClick={() => {
                     const updated = schedules.map((s, i) => i === index ? { ...s, enabled: !s.enabled } : s);
                     setSchedules(updated);
-                    localStorage.setItem('backup_schedules', JSON.stringify(updated));
                   }}
                   className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
                     schedule.enabled ? 'bg-blue-600' : 'bg-gray-200'
@@ -402,7 +389,6 @@ export function BackupPage() {
               };
               const updated = [newBackup, ...backups];
               setBackups(updated);
-              localStorage.setItem('backups', JSON.stringify(updated));
               setName('');
               setType('full');
               setLocation('cloud');

--- a/src/components/pages/PrivacyPage.tsx
+++ b/src/components/pages/PrivacyPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useUserData } from '../../utils/userData';
 import { AnimatedAlert } from '../AnimatedAlert';
 import {
   Shield,
@@ -11,7 +12,7 @@ import {
 } from 'lucide-react';
 
 export function PrivacyPage() {
-  const [settings, setSettings] = useState({
+  const [settings, setSettings] = useUserData('privacy_settings', {
     profileVisibility: 'private',
     searchEngineIndexing: false,
     dataSharing: false,
@@ -41,12 +42,11 @@ export function PrivacyPage() {
   };
 
   const saveChanges = () => {
-    localStorage.setItem('privacy_settings', JSON.stringify(settings));
     setAlert({ message: 'Settings saved', type: 'success' });
   };
 
   const exportData = () => {
-    const data = localStorage.getItem('vault_settings') || '{}';
+    const data = JSON.stringify(settings);
     const blob = new Blob([data], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -58,7 +58,20 @@ export function PrivacyPage() {
   };
 
   const deleteAccount = () => {
-    localStorage.clear();
+    setSettings({
+      profileVisibility: 'private',
+      searchEngineIndexing: false,
+      dataSharing: false,
+      analyticsTracking: true,
+      cookieConsent: true,
+      emailMarketing: false,
+      thirdPartyIntegrations: false,
+      dataRetention: '25years',
+      encryptionLevel: 'aes256',
+      twoFactorAuth: true,
+      loginNotifications: true,
+      accessLogging: true,
+    });
     setAlert({ message: 'Account deleted', type: 'success' });
   };
 

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { useUserData } from '../utils/userData';
 
 interface Language {
   code: string;
@@ -144,13 +145,13 @@ interface LanguageProviderProps {
 }
 
 export function LanguageProvider({ children }: LanguageProviderProps) {
-  const [currentLanguage, setCurrentLanguage] = useState<Language>(languages[0]);
+  const [languageCode, setLanguageCode] = useUserData('language', languages[0].code);
+  const currentLanguage = languages.find(lang => lang.code === languageCode) || languages[0];
 
   const changeLanguage = (code: string) => {
     const language = languages.find(lang => lang.code === code);
     if (language) {
-      setCurrentLanguage(language);
-      localStorage.setItem('vault_language', code);
+      setLanguageCode(code);
     }
   };
 
@@ -158,12 +159,7 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
     return translations[currentLanguage.code]?.[key] || translations.en[key] || key;
   };
 
-  React.useEffect(() => {
-    const savedLanguage = localStorage.getItem('vault_language');
-    if (savedLanguage) {
-      changeLanguage(savedLanguage);
-    }
-  }, []);
+  // userData handles persistence
 
   return (
     <LanguageContext.Provider value={{


### PR DESCRIPTION
## Summary
- stop persisting settings and state in `localStorage`
- store user state with `useUserData` hook
- update pages to use server-backed storage instead of browser cache

## Testing
- `npm run build`
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e1b1adccc8322a0eae54c793cac49