### PR TITLE
Fix file path storage

### DIFF
--- a/server/Controllers/FilesController.cs
+++ b/server/Controllers/FilesController.cs
@@ -38,13 +38,13 @@ namespace VaultBackend.Controllers
 
             var userId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? "unknown";
 
-            var dir = Path.Combine(_env.ContentRootPath, "UploadedFiles", userId);
-            Directory.CreateDirectory(dir);
-            var filePath = Path.Combine(dir, Guid.NewGuid().ToString() + "_" + file.FileName);
+            var relativePath = Path.Combine("UploadedFiles", userId, Guid.NewGuid().ToString() + "_" + file.FileName);
+            var filePath = Path.Combine(_env.ContentRootPath, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
             using var stream = System.IO.File.OpenWrite(filePath);
             await file.CopyToAsync(stream);
 
-            var uploaded = new UploadedFile { Path = filePath, OriginalName = file.FileName, UserId = userId };
+            var uploaded = new UploadedFile { Path = relativePath, OriginalName = file.FileName, UserId = userId };
             _db.UploadedFiles.Add(uploaded);
             await _db.SaveChangesAsync();
             await _logger.LogAsync(userId, "Uploaded file", file.FileName);

--- a/server/Models/UploadedFile.cs
+++ b/server/Models/UploadedFile.cs
@@ -10,6 +10,7 @@ namespace VaultBackend.Models
         [Required]
         public string UserId { get; set; } = string.Empty;
 
+        // Path relative to the application root, e.g. "UploadedFiles/{userId}/filename"
         [Required]
         public string Path { get; set; } = string.Empty;
 

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { HubConnectionBuilder, HubConnection, HubConnectionState } from '@microsoft/signalr';
+import { HubConnectionBuilder, HubConnection } from '@microsoft/signalr';
 import { useAuth } from '../../contexts/AuthContext';
 import { ChatMessage } from '../../types';
 import { fetchChatHistory, fetchFaqs } from '../../utils/api';


### PR DESCRIPTION
## Summary
- use relative paths when saving uploaded files
- clarify storage path in data model
- clean up unused import in ChatWidget

## Testing
- `dotnet build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_687e412a0990832ba980de7a114ea816