### PR TITLE
Add trustee and release scheduling features

### DIFF
--- a/server/Controllers/BeneficiariesController.cs
+++ b/server/Controllers/BeneficiariesController.cs
@@ -1,0 +1,80 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+using VaultBackend.Data;
+using VaultBackend.Models;
+using VaultBackend.Services;
+
+namespace VaultBackend.Controllers
+{
+    [ApiController]
+    [Authorize]
+    [Route("api/beneficiaries")]
+    public class BeneficiariesController : ControllerBase
+    {
+        private readonly AppDbContext _db;
+        private readonly ActivityLogger _logger;
+
+        public BeneficiariesController(AppDbContext db, ActivityLogger logger)
+        {
+            _db = db;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> List()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            var items = await _db.Beneficiaries.Where(b => b.UserId == userId).ToListAsync();
+            return Ok(items);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] Beneficiary beneficiary)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            beneficiary.Id = Guid.NewGuid().ToString();
+            beneficiary.UserId = userId;
+            beneficiary.CreatedAt = DateTime.UtcNow;
+            _db.Beneficiaries.Add(beneficiary);
+            await _db.SaveChangesAsync();
+            await _logger.LogAsync(userId, "Added beneficiary", beneficiary.Email);
+            return Ok(beneficiary);
+        }
+
+        [HttpPost("{id}/verify")]
+        public async Task<IActionResult> Verify(string id)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            var item = await _db.Beneficiaries.FirstOrDefaultAsync(b => b.Id == id && b.UserId == userId);
+            if (item == null) return NotFound();
+
+            item.Verified = true;
+            await _db.SaveChangesAsync();
+            await _logger.LogAsync(userId, "Verified beneficiary", item.Email);
+            return Ok();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(string id)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            var item = await _db.Beneficiaries.FirstOrDefaultAsync(b => b.Id == id && b.UserId == userId);
+            if (item == null) return NotFound();
+
+            _db.Beneficiaries.Remove(item);
+            await _db.SaveChangesAsync();
+            await _logger.LogAsync(userId, "Removed beneficiary", item.Email);
+            return Ok();
+        }
+    }
+}

--- a/server/Controllers/ReleasesController.cs
+++ b/server/Controllers/ReleasesController.cs
@@ -1,0 +1,80 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+using VaultBackend.Data;
+using VaultBackend.Models;
+using VaultBackend.Services;
+
+namespace VaultBackend.Controllers
+{
+    [ApiController]
+    [Authorize]
+    [Route("api/releases")]
+    public class ReleasesController : ControllerBase
+    {
+        private readonly AppDbContext _db;
+        private readonly ActivityLogger _logger;
+
+        public ReleasesController(AppDbContext db, ActivityLogger logger)
+        {
+            _db = db;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> List()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            var items = await _db.ReleaseSchedules.Where(r => r.UserId == userId).ToListAsync();
+            return Ok(items);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] ReleaseSchedule schedule)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            schedule.Id = Guid.NewGuid().ToString();
+            schedule.UserId = userId;
+            schedule.CreatedAt = DateTime.UtcNow;
+            _db.ReleaseSchedules.Add(schedule);
+            await _db.SaveChangesAsync();
+            await _logger.LogAsync(userId, "Scheduled release", schedule.FilePath);
+            return Ok(schedule);
+        }
+
+        [HttpPost("{id}/trigger")]
+        public async Task<IActionResult> Trigger(string id)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            var schedule = await _db.ReleaseSchedules.FirstOrDefaultAsync(r => r.Id == id && r.UserId == userId);
+            if (schedule == null) return NotFound();
+
+            schedule.Released = true;
+            await _db.SaveChangesAsync();
+            await _logger.LogAsync(userId, "Triggered release", schedule.FilePath);
+            return Ok();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(string id)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            var schedule = await _db.ReleaseSchedules.FirstOrDefaultAsync(r => r.Id == id && r.UserId == userId);
+            if (schedule == null) return NotFound();
+
+            _db.ReleaseSchedules.Remove(schedule);
+            await _db.SaveChangesAsync();
+            await _logger.LogAsync(userId, "Deleted release", schedule.FilePath);
+            return Ok();
+        }
+    }
+}

--- a/server/Controllers/TrusteesController.cs
+++ b/server/Controllers/TrusteesController.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+using VaultBackend.Data;
+using VaultBackend.Models;
+using VaultBackend.Services;
+
+namespace VaultBackend.Controllers
+{
+    [ApiController]
+    [Authorize]
+    [Route("api/trustees")]
+    public class TrusteesController : ControllerBase
+    {
+        private readonly AppDbContext _db;
+        private readonly ActivityLogger _logger;
+
+        public TrusteesController(AppDbContext db, ActivityLogger logger)
+        {
+            _db = db;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> List()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            var trustees = await _db.Trustees.Where(t => t.UserId == userId).ToListAsync();
+            return Ok(trustees);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] Trustee trustee)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            trustee.Id = Guid.NewGuid().ToString();
+            trustee.UserId = userId;
+            trustee.CreatedAt = DateTime.UtcNow;
+            _db.Trustees.Add(trustee);
+            await _db.SaveChangesAsync();
+            await _logger.LogAsync(userId, "Added trustee", trustee.Email);
+            return Ok(trustee);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(string id)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            var trustee = await _db.Trustees.FirstOrDefaultAsync(t => t.Id == id && t.UserId == userId);
+            if (trustee == null) return NotFound();
+
+            _db.Trustees.Remove(trustee);
+            await _db.SaveChangesAsync();
+            await _logger.LogAsync(userId, "Removed trustee", trustee.Email);
+            return Ok();
+        }
+    }
+}

--- a/server/Data/AppDbContext.cs
+++ b/server/Data/AppDbContext.cs
@@ -17,6 +17,7 @@ namespace VaultBackend.Data
         public DbSet<ChatMessage> ChatMessages => Set<ChatMessage>();
         public DbSet<ActivityLog> ActivityLogs => Set<ActivityLog>();
         public DbSet<UserData> UserData => Set<UserData>();
+        public DbSet<Beneficiary> Beneficiaries => Set<Beneficiary>();
         public DbSet<Trustee> Trustees => Set<Trustee>();
         public DbSet<ReleaseSchedule> ReleaseSchedules => Set<ReleaseSchedule>();
     }

--- a/server/Data/AppDbContext.cs
+++ b/server/Data/AppDbContext.cs
@@ -17,5 +17,7 @@ namespace VaultBackend.Data
         public DbSet<ChatMessage> ChatMessages => Set<ChatMessage>();
         public DbSet<ActivityLog> ActivityLogs => Set<ActivityLog>();
         public DbSet<UserData> UserData => Set<UserData>();
+        public DbSet<Trustee> Trustees => Set<Trustee>();
+        public DbSet<ReleaseSchedule> ReleaseSchedules => Set<ReleaseSchedule>();
     }
 }

--- a/server/Models/Beneficiary.cs
+++ b/server/Models/Beneficiary.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace VaultBackend.Models
+{
+    public class Beneficiary
+    {
+        [Key]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        [Required]
+        public string UserId { get; set; } = string.Empty;
+
+        [Required]
+        public string Name { get; set; } = string.Empty;
+
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; } = string.Empty;
+
+        public bool Verified { get; set; } = false;
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/server/Models/ReleaseSchedule.cs
+++ b/server/Models/ReleaseSchedule.cs
@@ -21,6 +21,9 @@ namespace VaultBackend.Models
         [EmailAddress]
         public string BeneficiaryEmail { get; set; } = string.Empty;
 
+        public string? BeneficiaryId { get; set; }
+        public Beneficiary? Beneficiary { get; set; }
+
         public bool RequiresApproval { get; set; } = false;
 
         public bool Released { get; set; } = false;

--- a/server/Models/ReleaseSchedule.cs
+++ b/server/Models/ReleaseSchedule.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace VaultBackend.Models
+{
+    public class ReleaseSchedule
+    {
+        [Key]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        [Required]
+        public string UserId { get; set; } = string.Empty;
+
+        [Required]
+        public string FilePath { get; set; } = string.Empty;
+
+        public DateTime ReleaseDate { get; set; }
+
+        [Required]
+        public string TriggerEvent { get; set; } = "date"; // date, inactivity, trustee
+
+        [EmailAddress]
+        public string BeneficiaryEmail { get; set; } = string.Empty;
+
+        public bool RequiresApproval { get; set; } = false;
+
+        public bool Released { get; set; } = false;
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/server/Models/Trustee.cs
+++ b/server/Models/Trustee.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace VaultBackend.Models
+{
+    public class Trustee
+    {
+        [Key]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        [Required]
+        public string UserId { get; set; } = string.Empty;
+
+        [Required]
+        public string Name { get; set; } = string.Empty;
+
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; } = string.Empty;
+
+        [Required]
+        public string Tier { get; set; } = "reviewer"; // reviewer, executor, recipient
+
+        public bool Verified { get; set; } = false;
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -243,6 +243,32 @@ using (var scope = app.Services.CreateScope())
         }
     }
 
+    // Ensure Trustees table exists
+    using (var check = conn.CreateCommand())
+    {
+        check.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='Trustees';";
+        var exists = check.ExecuteScalar() != null;
+        if (!exists)
+        {
+            using var create = conn.CreateCommand();
+            create.CommandText = "CREATE TABLE Trustees (Id TEXT PRIMARY KEY, UserId TEXT NOT NULL, Name TEXT NOT NULL, Email TEXT NOT NULL, Tier TEXT NOT NULL, Verified INTEGER NOT NULL, CreatedAt TEXT NOT NULL);";
+            create.ExecuteNonQuery();
+        }
+    }
+
+    // Ensure ReleaseSchedules table exists
+    using (var check = conn.CreateCommand())
+    {
+        check.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='ReleaseSchedules';";
+        var exists = check.ExecuteScalar() != null;
+        if (!exists)
+        {
+            using var create = conn.CreateCommand();
+            create.CommandText = "CREATE TABLE ReleaseSchedules (Id TEXT PRIMARY KEY, UserId TEXT NOT NULL, FilePath TEXT NOT NULL, ReleaseDate TEXT NOT NULL, TriggerEvent TEXT NOT NULL, BeneficiaryEmail TEXT, RequiresApproval INTEGER NOT NULL, Released INTEGER NOT NULL, CreatedAt TEXT NOT NULL);";
+            create.ExecuteNonQuery();
+        }
+    }
+
     conn.Close();
 }
 

--- a/server/Services/ReleaseEngine.cs
+++ b/server/Services/ReleaseEngine.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using VaultBackend.Data;
+using VaultBackend.Hubs;
+using VaultBackend.Models;
+
+namespace VaultBackend.Services
+{
+    public class ReleaseEngine : BackgroundService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly IHubContext<ActivityHub> _hub;
+
+        public ReleaseEngine(IServiceScopeFactory scopeFactory, IHubContext<ActivityHub> hub)
+        {
+            _scopeFactory = scopeFactory;
+            _hub = hub;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+                    var logger = scope.ServiceProvider.GetRequiredService<ActivityLogger>();
+                    var now = DateTime.UtcNow;
+                    var pending = await db.ReleaseSchedules
+                        .Include(r => r.Beneficiary)
+                        .Where(r => !r.Released && r.ReleaseDate <= now)
+                        .ToListAsync(stoppingToken);
+                    foreach (var rel in pending)
+                    {
+                        rel.Released = true;
+                        await db.SaveChangesAsync(stoppingToken);
+                        await logger.LogAsync(rel.UserId, "Auto release", rel.FilePath);
+                        await _hub.Clients.Group(rel.UserId).SendAsync("ReleaseTriggered", new
+                        {
+                            rel.Id,
+                            rel.FilePath,
+                            rel.BeneficiaryEmail
+                        }, cancellationToken: stoppingToken);
+                    }
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+        }
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { BlockchainPage } from './components/pages/BlockchainPage';
 import { AboutPage } from './components/pages/AboutPage';
 import { TrusteesPage } from './components/pages/TrusteesPage';
 import { ReleasesPage } from './components/pages/ReleasesPage';
+import { BeneficiariesPage } from './components/pages/BeneficiariesPage';
 import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 
 function AppContent() {
@@ -65,6 +66,7 @@ function AppContent() {
         <Route path="/backup" element={<BackupPage />} />
         <Route path="/blockchain" element={<BlockchainPage />} />
         <Route path="/trustees" element={<TrusteesPage />} />
+        <Route path="/beneficiaries" element={<BeneficiariesPage />} />
         <Route path="/releases" element={<ReleasesPage />} />
         <Route path="/about" element={<AboutPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,8 @@ import { APIPage } from './components/pages/APIPage';
 import { BackupPage } from './components/pages/BackupPage';
 import { BlockchainPage } from './components/pages/BlockchainPage';
 import { AboutPage } from './components/pages/AboutPage';
+import { TrusteesPage } from './components/pages/TrusteesPage';
+import { ReleasesPage } from './components/pages/ReleasesPage';
 import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 
 function AppContent() {
@@ -62,6 +64,8 @@ function AppContent() {
         <Route path="/api" element={user?.role === 'admin' ? <APIPage /> : <div className="p-6">Access denied</div>} />
         <Route path="/backup" element={<BackupPage />} />
         <Route path="/blockchain" element={<BlockchainPage />} />
+        <Route path="/trustees" element={<TrusteesPage />} />
+        <Route path="/releases" element={<ReleasesPage />} />
         <Route path="/about" element={<AboutPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -19,7 +19,9 @@ import {
   ChevronRight,
   Globe,
   Key,
-  Info
+  Info,
+  UserCheck,
+  Lock
 } from 'lucide-react';
 
 import { NavLink } from 'react-router-dom';
@@ -46,6 +48,8 @@ export function Navigation({ collapsed, onToggleCollapse }: NavigationProps) {
     ...(user?.role === 'admin' ? [{ name: t('analytics'), to: '/analytics', icon: BarChart3 }] : []),
     ...(user?.role === 'admin' ? [{ name: 'API', to: '/api', icon: Key }] : []),
     { name: 'Blockchain', to: '/blockchain', icon: Vault },
+    { name: 'Trustees', to: '/trustees', icon: UserCheck },
+    { name: 'Releases', to: '/releases', icon: Lock },
     { name: t('settings'), to: '/settings', icon: Settings },
     { name: t('templates'), to: '/templates', icon: FileText },
     { name: t('export'), to: '/export', icon: Download },

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -49,6 +49,7 @@ export function Navigation({ collapsed, onToggleCollapse }: NavigationProps) {
     ...(user?.role === 'admin' ? [{ name: 'API', to: '/api', icon: Key }] : []),
     { name: 'Blockchain', to: '/blockchain', icon: Vault },
     { name: 'Trustees', to: '/trustees', icon: UserCheck },
+    { name: 'Beneficiaries', to: '/beneficiaries', icon: UserCheck },
     { name: 'Releases', to: '/releases', icon: Lock },
     { name: t('settings'), to: '/settings', icon: Settings },
     { name: t('templates'), to: '/templates', icon: FileText },

--- a/src/components/pages/BeneficiariesPage.tsx
+++ b/src/components/pages/BeneficiariesPage.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react';
+import { User, CheckCircle, Mail, PlusCircle, Trash2 } from 'lucide-react';
+import { useAuth } from '../../contexts/AuthContext';
+import {
+  fetchBeneficiaries,
+  addBeneficiary,
+  removeBeneficiary,
+  verifyBeneficiary,
+} from '../../utils/api';
+import { AnimatedAlert } from '../AnimatedAlert';
+
+interface BeneficiaryItem {
+  id: string;
+  name: string;
+  email: string;
+  verified: boolean;
+}
+
+export function BeneficiariesPage() {
+  const { token, isAuthenticated } = useAuth();
+  const [beneficiaries, setBeneficiaries] = useState<BeneficiaryItem[]>([]);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [alert, setAlert] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated || !token) return;
+    load();
+  }, [isAuthenticated, token]);
+
+  const load = async () => {
+    try {
+      const data = await fetchBeneficiaries(token!);
+      setBeneficiaries(data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const onAdd = async () => {
+    if (!token) return;
+    try {
+      await addBeneficiary(token, { name, email });
+      setName('');
+      setEmail('');
+      setAlert('Beneficiary added');
+      load();
+    } catch (e) {
+      console.error(e);
+      setAlert('Failed to add');
+    }
+  };
+
+  const onRemove = async (id: string) => {
+    if (!token) return;
+    try {
+      await removeBeneficiary(token, id);
+      load();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const onVerify = async (id: string) => {
+    if (!token) return;
+    try {
+      await verifyBeneficiary(token, id);
+      load();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      {alert && <AnimatedAlert message={alert} type="success" onClose={() => setAlert(null)} />}
+      <div className="relative px-6 pt-10 pb-8 rounded-3xl bg-white/60 backdrop-blur-lg shadow-xl border border-white/30 overflow-hidden">
+        <h1 className="text-4xl font-extrabold text-gray-900">Beneficiaries</h1>
+        <p className="text-lg text-gray-700 mt-2">Manage who will receive your files</p>
+        <div className="absolute -top-10 -right-10 w-48 h-48 bg-green-400/20 rounded-full blur-2xl animate-pulse" />
+      </div>
+      <div className="glassy-card p-6 rounded-3xl border border-white/30 shadow-xl space-y-4">
+        <h3 className="text-lg font-bold">Add Beneficiary</h3>
+        <div className="flex flex-col sm:flex-row gap-2">
+          <input className="border rounded px-3 py-2 flex-1 bg-white/80" placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
+          <input className="border rounded px-3 py-2 flex-1 bg-white/80" placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+          <button onClick={onAdd} className="bg-primary-600 text-white rounded px-4 py-2">
+            <PlusCircle className="inline h-5 w-5 mr-1" /> Add
+          </button>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {beneficiaries.map((b) => (
+          <div key={b.id} className="glassy-card rounded-2xl border border-white/30 p-5 shadow-lg backdrop-blur-lg relative overflow-hidden">
+            <div className="absolute -top-6 -right-6 w-16 h-16 bg-green-400/10 rounded-full blur-xl" />
+            <div className="flex items-center space-x-3 mb-2 relative z-10">
+              <div className="p-2 bg-white/60 rounded-xl shadow">
+                <User className="h-5 w-5 text-gray-600" />
+              </div>
+              <h3 className="text-lg font-bold text-gray-900">{b.name}</h3>
+            </div>
+            <div className="flex items-center text-sm text-gray-600 mb-3 relative z-10">
+              <Mail className="h-4 w-4 mr-1" /> {b.email}
+            </div>
+            <div className="flex items-center justify-between relative z-10">
+              {b.verified ? (
+                <CheckCircle className="h-5 w-5 text-green-600" />
+              ) : (
+                <button onClick={() => onVerify(b.id)} className="text-primary-600 hover:underline text-sm flex items-center">
+                  <CheckCircle className="h-4 w-4 mr-1" /> Verify
+                </button>
+              )}
+              <button onClick={() => onRemove(b.id)} className="p-2 text-red-500 hover:text-red-700 rounded-lg hover:bg-red-50 transition">
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      <style>{`
+        .glassy-card {
+          background: rgba(255,255,255,0.7);
+          backdrop-filter: blur(12px);
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/pages/ReleasesPage.tsx
+++ b/src/components/pages/ReleasesPage.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import { fetchReleases, addRelease, triggerRelease } from '../../utils/api';
+import { AnimatedAlert } from '../AnimatedAlert';
+
+interface ReleaseItem {
+  id: string;
+  filePath: string;
+  releaseDate: string;
+  triggerEvent: string;
+  beneficiaryEmail: string;
+  requiresApproval: boolean;
+  released: boolean;
+}
+
+export function ReleasesPage() {
+  const { token, isAuthenticated } = useAuth();
+  const [releases, setReleases] = useState<ReleaseItem[]>([]);
+  const [filePath, setFilePath] = useState('');
+  const [releaseDate, setReleaseDate] = useState('');
+  const [triggerEvent, setTriggerEvent] = useState('date');
+  const [beneficiaryEmail, setBeneficiaryEmail] = useState('');
+  const [alert, setAlert] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated || !token) return;
+    load();
+  }, [isAuthenticated, token]);
+
+  const load = async () => {
+    try {
+      const data = await fetchReleases(token!);
+      setReleases(data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const onAdd = async () => {
+    if (!token) return;
+    try {
+      await addRelease(token, { filePath, releaseDate, triggerEvent, beneficiaryEmail, requiresApproval: false });
+      setFilePath('');
+      setReleaseDate('');
+      setTriggerEvent('date');
+      setBeneficiaryEmail('');
+      setAlert('Release scheduled');
+      load();
+    } catch (e) {
+      console.error(e);
+      setAlert('Failed to schedule');
+    }
+  };
+
+  const onTrigger = async (id: string) => {
+    if (!token) return;
+    try {
+      await triggerRelease(token, id);
+      load();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {alert && (
+        <AnimatedAlert message={alert} type="success" onClose={() => setAlert(null)} />
+      )}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Scheduled Releases</h1>
+      </div>
+      <div className="bg-white shadow rounded-lg p-4 space-y-4">
+        <div className="grid grid-cols-1 sm:grid-cols-4 gap-2">
+          <input
+            className="border rounded px-3 py-2"
+            placeholder="File Path"
+            value={filePath}
+            onChange={(e) => setFilePath(e.target.value)}
+          />
+          <input
+            type="date"
+            className="border rounded px-3 py-2"
+            value={releaseDate}
+            onChange={(e) => setReleaseDate(e.target.value)}
+          />
+          <select
+            className="border rounded px-3 py-2"
+            value={triggerEvent}
+            onChange={(e) => setTriggerEvent(e.target.value)}
+          >
+            <option value="date">Date</option>
+            <option value="inactivity">Inactivity</option>
+            <option value="trustee">Trustee Approval</option>
+          </select>
+          <input
+            className="border rounded px-3 py-2"
+            placeholder="Beneficiary Email"
+            value={beneficiaryEmail}
+            onChange={(e) => setBeneficiaryEmail(e.target.value)}
+          />
+          <button
+            onClick={onAdd}
+            className="bg-primary-600 text-white rounded px-4 py-2"
+          >
+            Add
+          </button>
+        </div>
+        <table className="min-w-full mt-4">
+          <thead>
+            <tr className="text-left">
+              <th className="py-2">File</th>
+              <th className="py-2">Release</th>
+              <th className="py-2">Trigger</th>
+              <th className="py-2">Beneficiary</th>
+              <th className="py-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {releases.map((r) => (
+              <tr key={r.id} className="border-t">
+                <td className="py-2">{r.filePath}</td>
+                <td className="py-2">{new Date(r.releaseDate).toLocaleDateString()}</td>
+                <td className="py-2 capitalize">{r.triggerEvent}</td>
+                <td className="py-2">{r.beneficiaryEmail}</td>
+                <td className="py-2 text-right">
+                  {!r.released && (
+                    <button onClick={() => onTrigger(r.id)} className="text-primary-600 hover:underline">
+                      Trigger
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pages/ReleasesPage.tsx
+++ b/src/components/pages/ReleasesPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { HubConnection, HubConnectionBuilder } from '@microsoft/signalr';
 import { useAuth } from '../../contexts/AuthContext';
 import { fetchReleases, addRelease, triggerRelease } from '../../utils/api';
 import { AnimatedAlert } from '../AnimatedAlert';
@@ -21,10 +22,24 @@ export function ReleasesPage() {
   const [triggerEvent, setTriggerEvent] = useState('date');
   const [beneficiaryEmail, setBeneficiaryEmail] = useState('');
   const [alert, setAlert] = useState<string | null>(null);
+  const [filterStatus, setFilterStatus] = useState('all');
+  const connectionRef = useRef<HubConnection | null>(null);
 
   useEffect(() => {
     if (!isAuthenticated || !token) return;
     load();
+    const connection = new HubConnectionBuilder()
+      .withUrl('/hubs/activity', { accessTokenFactory: () => token })
+      .withAutomaticReconnect()
+      .build();
+    connection.on('ReleaseTriggered', () => {
+      load();
+    });
+    connection.start();
+    connectionRef.current = connection;
+    return () => {
+      connection.stop();
+    };
   }, [isAuthenticated, token]);
 
   const load = async () => {
@@ -62,79 +77,91 @@ export function ReleasesPage() {
     }
   };
 
+  const stats = {
+    pending: releases.filter((r) => !r.released).length,
+    completed: releases.filter((r) => r.released).length,
+  };
+
+  const filtered = releases.filter((r) =>
+    filterStatus === 'all' ? true : filterStatus === 'released' ? r.released : !r.released
+  );
+
   return (
-    <div className="space-y-6">
-      {alert && (
-        <AnimatedAlert message={alert} type="success" onClose={() => setAlert(null)} />
-      )}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Scheduled Releases</h1>
+    <div className="space-y-8">
+      {alert && <AnimatedAlert message={alert} type="success" onClose={() => setAlert(null)} />}
+
+      <div className="relative flex flex-col sm:flex-row sm:items-center sm:justify-between px-6 pt-10 pb-8 rounded-3xl bg-white/60 backdrop-blur-lg shadow-xl border border-white/30 overflow-hidden" style={{ background: 'linear-gradient(120deg,rgba(74,222,128,0.15),rgba(59,130,246,0.15) 100%)' }}>
+        <div>
+          <h1 className="text-4xl font-extrabold text-gray-900">Releases</h1>
+          <p className="mt-2 text-lg text-gray-700">Schedule and monitor secure file hand-offs</p>
+        </div>
+        <div className="absolute -top-10 -right-10 w-48 h-48 bg-green-400/20 rounded-full blur-2xl animate-pulse" />
+        <div className="absolute -bottom-10 -left-10 w-40 h-40 bg-blue-400/20 rounded-full blur-2xl animate-pulse" />
       </div>
-      <div className="bg-white shadow rounded-lg p-4 space-y-4">
-        <div className="grid grid-cols-1 sm:grid-cols-4 gap-2">
-          <input
-            className="border rounded px-3 py-2"
-            placeholder="File Path"
-            value={filePath}
-            onChange={(e) => setFilePath(e.target.value)}
-          />
-          <input
-            type="date"
-            className="border rounded px-3 py-2"
-            value={releaseDate}
-            onChange={(e) => setReleaseDate(e.target.value)}
-          />
-          <select
-            className="border rounded px-3 py-2"
-            value={triggerEvent}
-            onChange={(e) => setTriggerEvent(e.target.value)}
-          >
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {[
+          { label: 'Pending', value: stats.pending, color: 'from-yellow-100 to-yellow-50' },
+          { label: 'Completed', value: stats.completed, color: 'from-green-100 to-green-50' },
+        ].map((stat, i) => (
+          <div key={stat.label} className={`bg-gradient-to-br ${stat.color} p-6 rounded-2xl border border-white/40 shadow flex items-center space-x-4 glassy-card animate-fade-in`} style={{ animationDelay: `${i * 80}ms` }}>
+            <div>
+              <p className="text-sm font-medium text-gray-600">{stat.label}</p>
+              <p className="text-2xl font-extrabold text-gray-900 tracking-tight">{stat.value}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="glassy-card p-6 rounded-3xl border border-white/30 shadow-xl space-y-4">
+        <h3 className="text-lg font-bold text-gray-900">Schedule Release</h3>
+        <div className="grid grid-cols-1 md:grid-cols-5 gap-2">
+          <input className="border rounded px-3 py-2 bg-white/80" placeholder="File Path" value={filePath} onChange={(e) => setFilePath(e.target.value)} />
+          <input type="date" className="border rounded px-3 py-2 bg-white/80" value={releaseDate} onChange={(e) => setReleaseDate(e.target.value)} />
+          <select className="border rounded px-3 py-2 bg-white/80" value={triggerEvent} onChange={(e) => setTriggerEvent(e.target.value)}>
             <option value="date">Date</option>
             <option value="inactivity">Inactivity</option>
             <option value="trustee">Trustee Approval</option>
           </select>
-          <input
-            className="border rounded px-3 py-2"
-            placeholder="Beneficiary Email"
-            value={beneficiaryEmail}
-            onChange={(e) => setBeneficiaryEmail(e.target.value)}
-          />
-          <button
-            onClick={onAdd}
-            className="bg-primary-600 text-white rounded px-4 py-2"
-          >
-            Add
-          </button>
+          <input className="border rounded px-3 py-2 bg-white/80" placeholder="Beneficiary" value={beneficiaryEmail} onChange={(e) => setBeneficiaryEmail(e.target.value)} />
+          <button onClick={onAdd} className="bg-primary-600 text-white rounded px-4 py-2">Add</button>
         </div>
-        <table className="min-w-full mt-4">
-          <thead>
-            <tr className="text-left">
-              <th className="py-2">File</th>
-              <th className="py-2">Release</th>
-              <th className="py-2">Trigger</th>
-              <th className="py-2">Beneficiary</th>
-              <th className="py-2" />
-            </tr>
-          </thead>
-          <tbody>
-            {releases.map((r) => (
-              <tr key={r.id} className="border-t">
-                <td className="py-2">{r.filePath}</td>
-                <td className="py-2">{new Date(r.releaseDate).toLocaleDateString()}</td>
-                <td className="py-2 capitalize">{r.triggerEvent}</td>
-                <td className="py-2">{r.beneficiaryEmail}</td>
-                <td className="py-2 text-right">
-                  {!r.released && (
-                    <button onClick={() => onTrigger(r.id)} className="text-primary-600 hover:underline">
-                      Trigger
-                    </button>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
       </div>
+
+      <div className="bg-white/70 p-6 rounded-3xl border border-white/30 shadow-xl backdrop-blur-lg flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-4 sm:space-y-0">
+        <select value={filterStatus} onChange={(e) => setFilterStatus(e.target.value)} className="border border-gray-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-400 bg-white/80 shadow">
+          <option value="all">All</option>
+          <option value="pending">Pending</option>
+          <option value="released">Released</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        {filtered.map((r) => (
+          <div key={r.id} className="glassy-card rounded-2xl border border-white/30 p-5 shadow-lg backdrop-blur-lg flex items-center justify-between">
+            <div>
+              <p className="font-semibold text-gray-900">{r.filePath}</p>
+              <p className="text-sm text-gray-600">Release: {new Date(r.releaseDate).toLocaleDateString()} | {r.triggerEvent}</p>
+              <p className="text-sm text-gray-600">Beneficiary: {r.beneficiaryEmail}</p>
+            </div>
+            {!r.released && (
+              <button onClick={() => onTrigger(r.id)} className="text-primary-600 hover:underline">Trigger</button>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <style>{`
+        .glassy-card {
+          background: rgba(255,255,255,0.7);
+          backdrop-filter: blur(12px);
+        }
+        @keyframes fade-in {
+          from { opacity: 0; transform: translateY(16px); }
+          to { opacity: 1; transform: none; }
+        }
+        .animate-fade-in { animation: fade-in 0.7s cubic-bezier(.4,0,.2,1) both; }
+      `}</style>
     </div>
   );
 }

--- a/src/components/pages/TrusteesPage.tsx
+++ b/src/components/pages/TrusteesPage.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import { fetchTrustees, addTrustee, removeTrustee } from '../../utils/api';
+import { AnimatedAlert } from '../AnimatedAlert';
+
+interface TrusteeItem {
+  id: string;
+  name: string;
+  email: string;
+  tier: string;
+  verified: boolean;
+}
+
+export function TrusteesPage() {
+  const { token, isAuthenticated } = useAuth();
+  const [trustees, setTrustees] = useState<TrusteeItem[]>([]);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [tier, setTier] = useState('reviewer');
+  const [alert, setAlert] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated || !token) return;
+    load();
+  }, [isAuthenticated, token]);
+
+  const load = async () => {
+    try {
+      const data = await fetchTrustees(token!);
+      setTrustees(data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const onAdd = async () => {
+    if (!token) return;
+    try {
+      await addTrustee(token, { name, email, tier });
+      setName('');
+      setEmail('');
+      setTier('reviewer');
+      setAlert('Trustee added');
+      load();
+    } catch (e) {
+      console.error(e);
+      setAlert('Failed to add trustee');
+    }
+  };
+
+  const onRemove = async (id: string) => {
+    if (!token) return;
+    try {
+      await removeTrustee(token, id);
+      load();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {alert && (
+        <AnimatedAlert message={alert} type="success" onClose={() => setAlert(null)} />
+      )}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Trustees</h1>
+      </div>
+      <div className="bg-white shadow rounded-lg p-4 space-y-4">
+        <div className="flex flex-col sm:flex-row gap-2">
+          <input
+            className="border rounded px-3 py-2 flex-1"
+            placeholder="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <input
+            className="border rounded px-3 py-2 flex-1"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <select
+            className="border rounded px-3 py-2"
+            value={tier}
+            onChange={(e) => setTier(e.target.value)}
+          >
+            <option value="reviewer">Reviewer</option>
+            <option value="executor">Executor</option>
+            <option value="recipient">Recipient</option>
+          </select>
+          <button
+            onClick={onAdd}
+            className="bg-primary-600 text-white rounded px-4 py-2"
+          >
+            Add
+          </button>
+        </div>
+        <table className="min-w-full">
+          <thead>
+            <tr className="text-left">
+              <th className="py-2">Name</th>
+              <th className="py-2">Email</th>
+              <th className="py-2">Tier</th>
+              <th className="py-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {trustees.map((t) => (
+              <tr key={t.id} className="border-t">
+                <td className="py-2">{t.name}</td>
+                <td className="py-2">{t.email}</td>
+                <td className="py-2 capitalize">{t.tier}</td>
+                <td className="py-2 text-right">
+                  <button
+                    onClick={() => onRemove(t.id)}
+                    className="text-red-600 hover:underline"
+                  >
+                    Remove
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pages/TrusteesPage.tsx
+++ b/src/components/pages/TrusteesPage.tsx
@@ -1,4 +1,15 @@
 import { useEffect, useState } from 'react';
+import {
+  User,
+  UserCheck,
+  Gavel,
+  Gift,
+  Mail,
+  Search,
+  Trash2,
+  CheckCircle,
+  XCircle,
+} from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { fetchTrustees, addTrustee, removeTrustee } from '../../utils/api';
 import { AnimatedAlert } from '../AnimatedAlert';
@@ -17,6 +28,8 @@ export function TrusteesPage() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [tier, setTier] = useState('reviewer');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filterTier, setFilterTier] = useState('all');
   const [alert, setAlert] = useState<string | null>(null);
 
   useEffect(() => {
@@ -58,30 +71,93 @@ export function TrusteesPage() {
     }
   };
 
+  const counts = {
+    reviewer: trustees.filter((t) => t.tier === 'reviewer').length,
+    executor: trustees.filter((t) => t.tier === 'executor').length,
+    recipient: trustees.filter((t) => t.tier === 'recipient').length,
+    verified: trustees.filter((t) => t.verified).length,
+  };
+
+  const getTierColor = (value: string) => {
+    switch (value) {
+      case 'reviewer':
+        return 'bg-blue-100 text-blue-800 border-blue-200';
+      case 'executor':
+        return 'bg-purple-100 text-purple-800 border-purple-200';
+      case 'recipient':
+        return 'bg-green-100 text-green-800 border-green-200';
+      default:
+        return 'bg-gray-100 text-gray-800 border-gray-200';
+    }
+  };
+
+  const filteredTrustees = trustees.filter((t) => {
+    const matchSearch =
+      t.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      t.email.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchTier = filterTier === 'all' || t.tier === filterTier;
+    return matchSearch && matchTier;
+  });
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       {alert && (
         <AnimatedAlert message={alert} type="success" onClose={() => setAlert(null)} />
       )}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Trustees</h1>
+
+      {/* Header */}
+      <div
+        className="relative flex flex-col sm:flex-row sm:items-center sm:justify-between px-6 pt-10 pb-8 rounded-3xl bg-white/60 backdrop-blur-lg shadow-xl border border-white/30 overflow-hidden"
+        style={{ background: 'linear-gradient(120deg,rgba(59,130,246,0.10),rgba(236,72,153,0.10) 100%)' }}
+      >
+        <div>
+          <h1 className="text-4xl font-extrabold text-gray-900 drop-shadow-sm tracking-tight">Trustees</h1>
+          <p className="mt-2 text-lg text-gray-700">Manage estate contacts and permissions</p>
+        </div>
+        <div className="absolute -top-10 -right-10 w-48 h-48 bg-blue-400/20 rounded-full blur-2xl animate-pulse z-0" />
+        <div className="absolute -bottom-10 -left-10 w-40 h-40 bg-pink-400/20 rounded-full blur-2xl animate-pulse z-0" />
       </div>
-      <div className="bg-white shadow rounded-lg p-4 space-y-4">
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+        {[
+          { icon: <UserCheck className="h-7 w-7 text-blue-600" />, label: 'Reviewers', value: counts.reviewer, color: 'from-blue-100 to-blue-50' },
+          { icon: <Gavel className="h-7 w-7 text-purple-600" />, label: 'Executors', value: counts.executor, color: 'from-purple-100 to-purple-50' },
+          { icon: <Gift className="h-7 w-7 text-green-600" />, label: 'Recipients', value: counts.recipient, color: 'from-green-100 to-green-50' },
+          { icon: <CheckCircle className="h-7 w-7 text-teal-600" />, label: 'Verified', value: counts.verified, color: 'from-teal-100 to-teal-50' },
+        ].map((stat, i) => (
+          <div
+            key={stat.label}
+            className={`bg-gradient-to-br ${stat.color} p-6 rounded-2xl border border-white/40 shadow flex items-center space-x-4 glassy-card animate-fade-in`}
+            style={{ animationDelay: `${i * 80}ms` }}
+          >
+            <div className="p-3 bg-white/60 rounded-xl shadow">{stat.icon}</div>
+            <div>
+              <p className="text-sm font-medium text-gray-600">{stat.label}</p>
+              <p className="text-2xl font-extrabold text-gray-900 tracking-tight">{stat.value}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Add Trustee */}
+      <div className="glassy-card p-6 rounded-3xl border border-white/30 shadow-xl space-y-4">
+        <h3 className="text-lg font-bold text-gray-900">Add Trustee</h3>
         <div className="flex flex-col sm:flex-row gap-2">
           <input
-            className="border rounded px-3 py-2 flex-1"
+            className="border rounded px-3 py-2 flex-1 bg-white/80"
             placeholder="Name"
             value={name}
             onChange={(e) => setName(e.target.value)}
           />
           <input
-            className="border rounded px-3 py-2 flex-1"
+            className="border rounded px-3 py-2 flex-1 bg-white/80"
             placeholder="Email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
           />
           <select
-            className="border rounded px-3 py-2"
+            className="border rounded px-3 py-2 bg-white/80"
             value={tier}
             onChange={(e) => setTier(e.target.value)}
           >
@@ -96,34 +172,81 @@ export function TrusteesPage() {
             Add
           </button>
         </div>
-        <table className="min-w-full">
-          <thead>
-            <tr className="text-left">
-              <th className="py-2">Name</th>
-              <th className="py-2">Email</th>
-              <th className="py-2">Tier</th>
-              <th className="py-2" />
-            </tr>
-          </thead>
-          <tbody>
-            {trustees.map((t) => (
-              <tr key={t.id} className="border-t">
-                <td className="py-2">{t.name}</td>
-                <td className="py-2">{t.email}</td>
-                <td className="py-2 capitalize">{t.tier}</td>
-                <td className="py-2 text-right">
-                  <button
-                    onClick={() => onRemove(t.id)}
-                    className="text-red-600 hover:underline"
-                  >
-                    Remove
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
       </div>
+
+      {/* Search & Filters */}
+      <div className="bg-white/70 p-6 rounded-3xl border border-white/30 shadow-xl backdrop-blur-lg flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-4 sm:space-y-0">
+        <div className="flex-1 relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Search trustees..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="pl-10 pr-3 py-2 border border-gray-200 rounded-xl w-full bg-white/80 shadow focus:outline-none focus:ring-2 focus:ring-primary-400"
+          />
+        </div>
+        <select
+          value={filterTier}
+          onChange={(e) => setFilterTier(e.target.value)}
+          className="border border-gray-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-400 bg-white/80 shadow"
+        >
+          <option value="all">All Tiers</option>
+          <option value="reviewer">Reviewer</option>
+          <option value="executor">Executor</option>
+          <option value="recipient">Recipient</option>
+        </select>
+      </div>
+
+      {/* Trustees List */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {filteredTrustees.map((t) => (
+          <div
+            key={t.id}
+            className="glassy-card rounded-2xl border border-white/30 p-5 shadow-lg backdrop-blur-lg relative overflow-hidden"
+          >
+            <div className="absolute -top-6 -right-6 w-16 h-16 bg-blue-400/10 rounded-full blur-xl" />
+            <div className="flex items-center space-x-3 mb-2 relative z-10">
+              <div className="p-2 bg-white/60 rounded-xl shadow">
+                <User className="h-5 w-5 text-gray-600" />
+              </div>
+              <h3 className="text-lg font-bold text-gray-900">{t.name}</h3>
+            </div>
+            <div className="flex items-center text-sm text-gray-600 mb-3 relative z-10">
+              <Mail className="h-4 w-4 mr-1" /> {t.email}
+            </div>
+            <div className="flex items-center justify-between relative z-10">
+              <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold border ${getTierColor(t.tier)}`}>{t.tier}</span>
+              <div className="flex items-center space-x-2">
+                {t.verified ? (
+                  <CheckCircle className="h-5 w-5 text-green-600" />
+                ) : (
+                  <XCircle className="h-5 w-5 text-gray-400" />
+                )}
+                <button
+                  onClick={() => onRemove(t.id)}
+                  className="p-2 text-red-500 hover:text-red-700 rounded-lg hover:bg-red-50 transition"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Custom card styles */}
+      <style>{`
+        .glassy-card {
+          background: rgba(255,255,255,0.7);
+          backdrop-filter: blur(12px);
+        }
+        @keyframes fade-in {
+          from { opacity: 0; transform: translateY(16px); }
+          to { opacity: 1; transform: none; }
+        }
+        .animate-fade-in { animation: fade-in 0.7s cubic-bezier(.4,0,.2,1) both; }
+      `}</style>
     </div>
   );
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -186,6 +186,43 @@ export async function removeTrustee(token: string, id: string) {
   if (!res.ok) throw new Error(await res.text());
 }
 
+export async function fetchBeneficiaries(token: string) {
+  const res = await fetch(`${API_BASE}/api/beneficiaries`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function addBeneficiary(token: string, data: { name: string; email: string }) {
+  const res = await fetch(`${API_BASE}/api/beneficiaries`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function removeBeneficiary(token: string, id: string) {
+  const res = await fetch(`${API_BASE}/api/beneficiaries/${id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(await res.text());
+}
+
+export async function verifyBeneficiary(token: string, id: string) {
+  const res = await fetch(`${API_BASE}/api/beneficiaries/${id}/verify`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(await res.text());
+}
+
 export async function fetchReleases(token: string) {
   const res = await fetch(`${API_BASE}/api/releases`, {
     headers: { Authorization: `Bearer ${token}` },

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -156,3 +156,61 @@ export async function fetchFaqs(token: string) {
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
+
+export async function fetchTrustees(token: string) {
+  const res = await fetch(`${API_BASE}/api/trustees`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function addTrustee(token: string, data: { name: string; email: string; tier: string }) {
+  const res = await fetch(`${API_BASE}/api/trustees`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function removeTrustee(token: string, id: string) {
+  const res = await fetch(`${API_BASE}/api/trustees/${id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(await res.text());
+}
+
+export async function fetchReleases(token: string) {
+  const res = await fetch(`${API_BASE}/api/releases`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function addRelease(token: string, data: Record<string, unknown>) {
+  const res = await fetch(`${API_BASE}/api/releases`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function triggerRelease(token: string, id: string) {
+  const res = await fetch(`${API_BASE}/api/releases/${id}/trigger`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(await res.text());
+}


### PR DESCRIPTION
## Summary
- add Trustee and ReleaseSchedule models
- expand database context and migration setup
- create API controllers for trustees and file release scheduling
- expose new API helpers and React pages
- wire up navigation links and routes

## Testing
- `npm run lint`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_b_6880b6e0f934832d9624ce328b1dbc50