### PR TITLE
refactor: update pages with modern UI

### DIFF
--- a/src/components/pages/APIPage.tsx
+++ b/src/components/pages/APIPage.tsx
@@ -4,15 +4,15 @@ import { fetchApiKeys, createApiKey, deleteApiKey, regenerateApiKey } from '../.
 import { fetchApiEndpoints } from '../../utils/api';
 import { useAuth } from '../../contexts/AuthContext';
 import { AnimatedAlert } from '../AnimatedAlert';
-import { 
-  Key, 
-  Plus, 
-  Copy, 
-  Eye, 
-  EyeOff, 
-  Trash2, 
-  RefreshCw, 
-  Shield, 
+import {
+  Key,
+  Plus,
+  Copy,
+  Eye,
+  EyeOff,
+  Trash2,
+  RefreshCw,
+  Shield,
   Book,
   AlertTriangle,
   CheckCircle,
@@ -20,6 +20,7 @@ import {
   Activity,
   BarChart3
 } from 'lucide-react';
+import { motion } from 'framer-motion';
 
 
 
@@ -169,7 +170,7 @@ export function APIPage() {
   );
 
   return (
-    <div className="space-y-6">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100">
       <APIKeyModal
         isOpen={showCreateModal}
         onClose={() => setShowCreateModal(false)}
@@ -182,13 +183,46 @@ export function APIPage() {
           onClose={() => setAlert(null)}
         />
       )}
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">API Management</h1>
-          <p className="mt-2 text-gray-600">Manage API keys and access to your Vault of Legacy data</p>
+
+      <div className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-r from-blue-600 via-purple-600 to-indigo-700"></div>
+        <div className="absolute inset-0 bg-black/20"></div>
+        <div className="relative px-6 py-16 sm:py-24">
+          <div className="mx-auto max-w-7xl">
+            <div className="text-center">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6 }}
+                className="flex justify-center mb-6"
+              >
+                <div className="p-4 bg-white/10 backdrop-blur-sm rounded-2xl border border-white/20">
+                  <Key className="h-12 w-12 text-white" />
+                </div>
+              </motion.div>
+              <motion.h1
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.1 }}
+                className="text-4xl sm:text-5xl font-bold text-white mb-4"
+              >
+                API Management
+              </motion.h1>
+              <motion.p
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.2 }}
+                className="text-xl text-blue-100 max-w-2xl mx-auto"
+              >
+                Manage API keys and access to your Vault of Legacy data
+              </motion.p>
+            </div>
+          </div>
         </div>
-        <div className="mt-4 sm:mt-0 flex space-x-3">
+      </div>
+
+      <div className="relative -mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 space-y-8">
+        <div className="flex flex-col sm:flex-row sm:justify-end gap-3">
           <button
             className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
             onClick={handleOpenDocs}
@@ -196,7 +230,7 @@ export function APIPage() {
             <Book className="h-4 w-4 mr-2" />
             API Documentation
           </button>
-          <button 
+          <button
             onClick={() => setShowCreateModal(true)}
             className="inline-flex items-center px-4 py-2 border border-transparent rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700"
           >
@@ -204,62 +238,60 @@ export function APIPage() {
             Create API Key
           </button>
         </div>
-      </div>
 
-      {/* API Usage Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-        <div className="bg-white p-6 rounded-xl border border-gray-200">
-          <div className="flex items-center">
-            <div className="p-2 bg-blue-100 rounded-lg">
-              <Key className="h-6 w-6 text-blue-600" />
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+          <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-white/50">
+            <div className="flex items-center">
+              <div className="p-2 bg-blue-100 rounded-lg">
+                <Key className="h-6 w-6 text-blue-600" />
+              </div>
+              <div className="ml-4">
+                <p className="text-sm font-medium text-gray-600">Active Keys</p>
+                <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                  {apiKeys.filter(k => k.status === 'active').length}
+                </p>
+              </div>
             </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-600">Active Keys</p>
-              <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                {apiKeys.filter(k => k.status === 'active').length}
-              </p>
+          </div>
+          <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-white/50">
+            <div className="flex items-center">
+              <div className="p-2 bg-green-100 rounded-lg">
+                <Activity className="h-6 w-6 text-green-600" />
+              </div>
+              <div className="ml-4">
+                <p className="text-sm font-medium text-gray-600">Total Requests</p>
+                <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                  {apiKeys.reduce((sum, key) => sum + (key.requests || 0), 0).toLocaleString()}
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-white/50">
+            <div className="flex items-center">
+              <div className="p-2 bg-purple-100 rounded-lg">
+                <BarChart3 className="h-6 w-6 text-purple-600" />
+              </div>
+              <div className="ml-4">
+                <p className="text-sm font-medium text-gray-600">Rate Limit</p>
+                <p className="text-2xl font-bold text-gray-900 dark:text-white">1000/hr</p>
+              </div>
+            </div>
+          </div>
+          <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-white/50">
+            <div className="flex items-center">
+              <div className="p-2 bg-orange-100 rounded-lg">
+                <Shield className="h-6 w-6 text-orange-600" />
+              </div>
+              <div className="ml-4">
+                <p className="text-sm font-medium text-gray-600">Security Level</p>
+                <p className="text-2xl font-bold text-gray-900 dark:text-white">High</p>
+              </div>
             </div>
           </div>
         </div>
-        <div className="bg-white p-6 rounded-xl border border-gray-200">
-          <div className="flex items-center">
-            <div className="p-2 bg-green-100 rounded-lg">
-              <Activity className="h-6 w-6 text-green-600" />
-            </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-600">Total Requests</p>
-              <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                {apiKeys.reduce((sum, key) => sum + (key.requests || 0), 0).toLocaleString()}
-              </p>
-            </div>
-          </div>
-        </div>
-        <div className="bg-white p-6 rounded-xl border border-gray-200">
-          <div className="flex items-center">
-            <div className="p-2 bg-purple-100 rounded-lg">
-              <BarChart3 className="h-6 w-6 text-purple-600" />
-            </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-600">Rate Limit</p>
-              <p className="text-2xl font-bold text-gray-900 dark:text-white">1000/hr</p>
-            </div>
-          </div>
-        </div>
-        <div className="bg-white p-6 rounded-xl border border-gray-200">
-          <div className="flex items-center">
-            <div className="p-2 bg-orange-100 rounded-lg">
-              <Shield className="h-6 w-6 text-orange-600" />
-            </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-600">Security Level</p>
-              <p className="text-2xl font-bold text-gray-900 dark:text-white">High</p>
-            </div>
-          </div>
-        </div>
-      </div>
 
       {/* API Keys List */}
-      <div className="bg-white rounded-xl border border-gray-200">
+      <div className="bg-white/80 backdrop-blur-sm rounded-2xl border border-white/50 shadow-lg">
         <div className="px-6 py-4 border-b border-gray-200 flex flex-col md:flex-row md:items-center md:justify-between gap-3">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white">API Keys</h3>
           <input
@@ -356,7 +388,7 @@ export function APIPage() {
       </div>
 
       {/* API Endpoints Documentation */}
-      <div className="bg-white rounded-xl border border-gray-200">
+      <div className="bg-white/80 backdrop-blur-sm rounded-2xl border border-white/50 shadow-lg">
         <div className="px-6 py-4 border-b border-gray-200">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white">API Endpoints</h3>
         </div>
@@ -376,7 +408,7 @@ export function APIPage() {
 
       {/* Rate Limiting & Security */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="bg-white rounded-xl border border-gray-200 p-6">
+        <div className="bg-white/80 backdrop-blur-sm rounded-2xl border border-white/50 p-6 shadow-lg">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Rate Limiting</h3>
           <div className="space-y-4">
             <div className="flex justify-between items-center">
@@ -400,7 +432,7 @@ export function APIPage() {
           </div>
         </div>
 
-        <div className="bg-white rounded-xl border border-gray-200 p-6">
+        <div className="bg-white/80 backdrop-blur-sm rounded-2xl border border-white/50 p-6 shadow-lg">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Security Features</h3>
           <div className="space-y-4">
             <div className="flex items-center space-x-3">
@@ -423,6 +455,7 @@ export function APIPage() {
               <AlertTriangle className="h-5 w-5 text-orange-600" />
               <span className="text-sm text-gray-900 dark:text-white">Audit logging</span>
             </div>
+          </div>
           </div>
         </div>
       </div>

--- a/src/components/pages/BlockchainPage.tsx
+++ b/src/components/pages/BlockchainPage.tsx
@@ -3,43 +3,63 @@ import { SendEthForm } from '../SendEthForm';
 import { ContractInteractionForm } from '../ContractInteractionForm';
 import { NetworkInfo } from '../NetworkInfo';
 import { LocalBlockchain } from '../LocalBlockchain';
+import { Network } from 'lucide-react';
+import { motion } from 'framer-motion';
 
 export function BlockchainPage() {
   return (
-    <div className="space-y-8">
-      <div
-        className="relative flex flex-col sm:flex-row sm:items-center sm:justify-between px-6 pt-10 pb-8 mb-6 rounded-3xl bg-white/60 backdrop-blur-lg shadow-xl border border-white/30 overflow-hidden"
-        style={{ background: 'linear-gradient(120deg,rgba(59,130,246,0.10),rgba(236,72,153,0.10) 100%)' }}
-      >
-        <div>
-          <h1 className="text-4xl font-extrabold text-gray-900 drop-shadow-sm tracking-tight">Blockchain</h1>
-          <p className="mt-2 text-lg text-gray-700">Interact with Ethereum in real time</p>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100">
+      <div className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-r from-blue-600 via-purple-600 to-indigo-700"></div>
+        <div className="absolute inset-0 bg-black/20"></div>
+        <div className="relative px-6 py-16 sm:py-24">
+          <div className="mx-auto max-w-7xl">
+            <div className="text-center">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6 }}
+                className="flex justify-center mb-6"
+              >
+                <div className="p-4 bg-white/10 backdrop-blur-sm rounded-2xl border border-white/20">
+                  <Network className="h-12 w-12 text-white" />
+                </div>
+              </motion.div>
+              <motion.h1
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.1 }}
+                className="text-4xl sm:text-5xl font-bold text-white mb-4"
+              >
+                Blockchain
+              </motion.h1>
+              <motion.p
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.2 }}
+                className="text-xl text-blue-100 max-w-2xl mx-auto"
+              >
+                Interact with Ethereum in real time
+              </motion.p>
+            </div>
+          </div>
         </div>
-        <div className="absolute -top-10 -right-10 w-48 h-48 bg-blue-400/20 rounded-full blur-2xl animate-pulse z-0" />
-        <div className="absolute -bottom-10 -left-10 w-40 h-40 bg-pink-400/20 rounded-full blur-2xl animate-pulse z-0" />
       </div>
-      <div className="grid lg:grid-cols-2 gap-6">
-        <div className="space-y-6">
-          <NetworkInfo />
-          <EthereumWallet />
-          <SendEthForm />
-        </div>
-        <div className="space-y-6">
-          <ContractInteractionForm />
-          <LocalBlockchain />
+
+      <div className="relative -mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="grid lg:grid-cols-2 gap-6">
+          <div className="space-y-6">
+            <NetworkInfo />
+            <EthereumWallet />
+            <SendEthForm />
+          </div>
+          <div className="space-y-6">
+            <ContractInteractionForm />
+            <LocalBlockchain />
+          </div>
         </div>
       </div>
-      <style>{`
-        .glassy-card {
-          background: rgba(255,255,255,0.7);
-          backdrop-filter: blur(12px);
-        }
-        @keyframes fade-in {
-          from { opacity: 0; transform: translateY(16px); }
-          to { opacity: 1; transform: none; }
-        }
-        .animate-fade-in { animation: fade-in 0.7s cubic-bezier(.4,0,.2,1) both; }
-      `}</style>
     </div>
   );
 }
+

--- a/src/components/pages/CollectionsPage.tsx
+++ b/src/components/pages/CollectionsPage.tsx
@@ -1,18 +1,19 @@
 import React, { useState } from 'react';
-import { 
-  Plus, 
-  Search, 
-  Grid3X3, 
-  List, 
-  Eye, 
-  Share2, 
-  Edit, 
+import {
+  Plus,
+  Search,
+  Grid3X3,
+  List,
+  Eye,
+  Share2,
+  Edit,
   Trash2,
   FolderOpen,
   ImageIcon,
   Lock,
   Globe
 } from 'lucide-react';
+import { motion } from 'framer-motion';
 import { FileManager, VaultItem } from '../FileManager';
 import { useUserData } from '../../utils/userData';
 
@@ -78,26 +79,58 @@ export function CollectionsPage() {
   };
 
   return (
-    <>
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Collections</h1>
-          <p className="mt-2 text-gray-600">Organize your assets into meaningful collections</p>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100">
+      <div className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-r from-blue-600 via-purple-600 to-indigo-700"></div>
+        <div className="absolute inset-0 bg-black/20"></div>
+        <div className="relative px-6 py-16 sm:py-24">
+          <div className="mx-auto max-w-7xl">
+            <div className="text-center">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6 }}
+                className="flex justify-center mb-6"
+              >
+                <div className="p-4 bg-white/10 backdrop-blur-sm rounded-2xl border border-white/20">
+                  <FolderOpen className="h-12 w-12 text-white" />
+                </div>
+              </motion.div>
+              <motion.h1
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.1 }}
+                className="text-4xl sm:text-5xl font-bold text-white mb-4"
+              >
+                Collections
+              </motion.h1>
+              <motion.p
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.2 }}
+                className="text-xl text-blue-100 max-w-2xl mx-auto"
+              >
+                Organize your assets into meaningful collections
+              </motion.p>
+            </div>
+          </div>
         </div>
-        <button
-          onClick={() => setShowCreateModal(true)}
-          className="mt-4 sm:mt-0 inline-flex items-center px-4 py-2 border border-transparent rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          <Plus className="h-4 w-4 mr-2" />
-          New Collection
-        </button>
       </div>
+
+      <div className="relative -mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 space-y-6">
+        <div className="flex justify-end">
+          <button
+            onClick={() => setShowCreateModal(true)}
+            className="inline-flex items-center px-4 py-2 border border-transparent rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            New Collection
+          </button>
+        </div>
 
       {/* Stats */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-        <div className="bg-white p-6 rounded-xl border border-gray-200">
+        <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-white/50">
           <div className="flex items-center">
             <div className="p-2 bg-blue-100 rounded-lg">
               <FolderOpen className="h-6 w-6 text-blue-600" />
@@ -108,7 +141,7 @@ export function CollectionsPage() {
             </div>
           </div>
         </div>
-        <div className="bg-white p-6 rounded-xl border border-gray-200">
+        <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-white/50">
           <div className="flex items-center">
             <div className="p-2 bg-green-100 rounded-lg">
               <ImageIcon className="h-6 w-6 text-green-600" />
@@ -121,7 +154,7 @@ export function CollectionsPage() {
             </div>
           </div>
         </div>
-        <div className="bg-white p-6 rounded-xl border border-gray-200">
+        <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-white/50">
           <div className="flex items-center">
             <div className="p-2 bg-purple-100 rounded-lg">
               <Globe className="h-6 w-6 text-purple-600" />
@@ -134,7 +167,7 @@ export function CollectionsPage() {
             </div>
           </div>
         </div>
-        <div className="bg-white p-6 rounded-xl border border-gray-200">
+        <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-white/50">
           <div className="flex items-center">
             <div className="p-2 bg-orange-100 rounded-lg">
               <Lock className="h-6 w-6 text-orange-600" />
@@ -150,7 +183,7 @@ export function CollectionsPage() {
       </div>
 
       {/* Search and View Controls */}
-      <div className="bg-white p-6 rounded-xl border border-gray-200">
+      <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-white/50">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-4 sm:space-y-0">
           <div className="flex-1 max-w-lg">
             <div className="relative">
@@ -184,7 +217,7 @@ export function CollectionsPage() {
       </div>
 
       {/* Collections Grid/List */}
-      <div className="bg-white rounded-xl border border-gray-200">
+      <div className="bg-white/80 backdrop-blur-sm rounded-2xl border border-white/50">
         {viewMode === 'grid' ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 p-6">
             {filteredCollections.map((collection) => (
@@ -546,6 +579,7 @@ export function CollectionsPage() {
         </div>
       </div>
     )}
-    </>
+  </div>
   );
 }
+

--- a/src/components/pages/SettingsPage.tsx
+++ b/src/components/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { AnimatedAlert } from '../AnimatedAlert';
 import { useAuth } from '../../contexts/AuthContext';
-import { 
+import {
   User,
   Shield,
   Bell,
@@ -15,8 +15,10 @@ import {
   Eye,
   EyeOff,
   Check,
-  Fingerprint
+  Fingerprint,
+  Settings as SettingsIcon
 } from 'lucide-react';
+import { motion } from 'framer-motion';
 import { enrollFingerprint, removeFingerprint, hasFingerprint } from '../../utils/fingerprint';
 import { changePassword, updateProfile } from '../../utils/api';
 
@@ -873,7 +875,7 @@ export function SettingsPage() {
   };
 
   return (
-    <div className="space-y-8">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100">
       {alert && (
         <AnimatedAlert
           message={alert.message}
@@ -881,71 +883,103 @@ export function SettingsPage() {
           onClose={() => setAlert(null)}
         />
       )}
-      {/* Glassy Animated Header */}
-      <div className="relative flex flex-col sm:flex-row sm:items-center sm:justify-between px-6 pt-10 pb-8 mb-6 rounded-3xl bg-white/60 backdrop-blur-lg shadow-xl border border-white/30 overflow-hidden" style={{background: 'linear-gradient(120deg,rgba(59,130,246,0.10),rgba(236,72,153,0.10) 100%)'}}>
-        <div>
-          <h1 className="text-4xl font-extrabold text-gray-900 drop-shadow-sm tracking-tight">Settings</h1>
-          <p className="mt-2 text-lg text-gray-700">Manage your account preferences and configuration</p>
-        </div>
-        <button
-          onClick={saveSettings}
-          disabled={isSaving}
-          className="mt-6 sm:mt-0 inline-flex items-center px-4 py-2 border border-transparent rounded-xl text-sm font-semibold text-white bg-gradient-to-r from-blue-600 to-pink-500 shadow-lg hover:scale-105 hover:shadow-xl transition disabled:opacity-60"
-        >
-          <Save className="h-4 w-4 mr-2" />
-          {isSaving ? 'Saving...' : 'Save Changes'}
-        </button>
-        {/* Animated background blobs */}
-        <div className="absolute -top-10 -right-10 w-48 h-48 bg-blue-400/20 rounded-full blur-2xl animate-pulse z-0" />
-        <div className="absolute -bottom-10 -left-10 w-40 h-40 bg-pink-400/20 rounded-full blur-2xl animate-pulse z-0" />
-      </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-        {/* Settings Navigation */}
-        <div className="lg:col-span-1">
-          <div className="glassy-card rounded-2xl border border-white/30 shadow-xl backdrop-blur-lg p-4">
-            <nav className="space-y-1">
-              {settingsSections.map((section) => {
-                const Icon = section.icon;
-                return (
-                  <button
-                    key={section.id}
-                    onClick={() => setActiveSection(section.id)}
-                    className={`w-full flex items-center space-x-3 px-3 py-2 text-left rounded-lg transition-all duration-200 ${
-                      activeSection === section.id
-                        ? 'bg-gradient-to-r from-blue-100 to-pink-100 text-blue-700 border-r-4 border-blue-600 scale-105 shadow-lg'
-                        : 'text-gray-700 hover:bg-gray-50'
-                    }`}
-                  >
-                    <Icon className={`h-5 w-5 ${activeSection === section.id ? 'text-blue-600' : 'text-gray-400'}`} />
-                    <span className="font-medium">{section.name}</span>
-                  </button>
-                );
-              })}
-            </nav>
-          </div>
-        </div>
-
-        {/* Settings Content */}
-        <div className="lg:col-span-3">
-          <div className="glassy-card rounded-2xl border border-white/30 shadow-xl backdrop-blur-lg p-6 space-y-6">
-            {renderCurrentSection()}
+      <div className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-r from-blue-600 via-purple-600 to-indigo-700"></div>
+        <div className="absolute inset-0 bg-black/20"></div>
+        <div className="relative px-6 py-16 sm:py-24">
+          <div className="mx-auto max-w-7xl">
+            <div className="text-center">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6 }}
+                className="flex justify-center mb-6"
+              >
+                <div className="p-4 bg-white/10 backdrop-blur-sm rounded-2xl border border-white/20">
+                  <SettingsIcon className="h-12 w-12 text-white" />
+                </div>
+              </motion.div>
+              <motion.h1
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.1 }}
+                className="text-4xl sm:text-5xl font-bold text-white mb-4"
+              >
+                Settings
+              </motion.h1>
+              <motion.p
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.2 }}
+                className="text-xl text-blue-100 max-w-2xl mx-auto"
+              >
+                Manage your account preferences and configuration
+              </motion.p>
+            </div>
           </div>
         </div>
       </div>
 
-      {/* Custom styles for glassy/animated cards */}
-      <style>{`
-        .glassy-card {
-          background: rgba(255,255,255,0.7);
-          backdrop-filter: blur(12px);
-        }
-        @keyframes fade-in {
-          from { opacity: 0; transform: translateY(16px); }
-          to { opacity: 1; transform: none; }
-        }
-        .animate-fade-in { animation: fade-in 0.7s cubic-bezier(.4,0,.2,1) both; }
-      `}</style>
+      <div className="relative -mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 space-y-8">
+        <div className="flex justify-end">
+          <button
+            onClick={saveSettings}
+            disabled={isSaving}
+            className="inline-flex items-center px-4 py-2 bg-gradient-to-r from-blue-600 to-pink-500 text-white rounded-xl shadow-lg hover:shadow-xl hover:scale-105 transition disabled:opacity-60"
+          >
+            <Save className="h-4 w-4 mr-2" />
+            {isSaving ? 'Saving...' : 'Save Changes'}
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+          {/* Settings Navigation */}
+          <div className="lg:col-span-1">
+            <div className="glassy-card rounded-2xl border border-white/30 shadow-xl backdrop-blur-lg p-4">
+              <nav className="space-y-1">
+                {settingsSections.map((section) => {
+                  const Icon = section.icon;
+                  return (
+                    <button
+                      key={section.id}
+                      onClick={() => setActiveSection(section.id)}
+                      className={`w-full flex items-center space-x-3 px-3 py-2 text-left rounded-lg transition-all duration-200 ${
+                        activeSection === section.id
+                          ? 'bg-gradient-to-r from-blue-100 to-pink-100 text-blue-700 border-r-4 border-blue-600 scale-105 shadow-lg'
+                          : 'text-gray-700 hover:bg-gray-50'
+                      }`}
+                    >
+                      <Icon className={`h-5 w-5 ${activeSection === section.id ? 'text-blue-600' : 'text-gray-400'}`} />
+                      <span className="font-medium">{section.name}</span>
+                    </button>
+                  );
+                })}
+              </nav>
+            </div>
+          </div>
+
+          {/* Settings Content */}
+          <div className="lg:col-span-3">
+            <div className="glassy-card rounded-2xl border border-white/30 shadow-xl backdrop-blur-lg p-6 space-y-6">
+              {renderCurrentSection()}
+            </div>
+          </div>
+        </div>
+
+        {/* Custom styles for glassy/animated cards */}
+        <style>{`
+          .glassy-card {
+            background: rgba(255,255,255,0.7);
+            backdrop-filter: blur(12px);
+          }
+          @keyframes fade-in {
+            from { opacity: 0; transform: translateY(16px); }
+            to { opacity: 1; transform: none; }
+          }
+          .animate-fade-in { animation: fade-in 0.7s cubic-bezier(.4,0,.2,1) both; }
+        `}</style>
+      </div>
     </div>
   );
 }

--- a/src/components/pages/SupportPage.tsx
+++ b/src/components/pages/SupportPage.tsx
@@ -14,6 +14,7 @@ import {
   Circle,
   AlertCircle,
 } from 'lucide-react';
+import { motion } from 'framer-motion';
 import { AnimatedAlert } from '../AnimatedAlert';
 
 export function SupportPage() {
@@ -126,164 +127,172 @@ export function SupportPage() {
   }, [tickets]);
 
   return (
-    <div className="space-y-6">
-      <div className="bg-gradient-to-r from-blue-500 to-purple-500 rounded-xl text-white p-6 shadow-lg flex items-center gap-4">
-        <MessageCircle className="w-10 h-10" />
-        <div>
-          <h1 className="text-2xl font-bold">Support</h1>
-          <p className="text-white/80">Create tickets and review your requests.</p>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
-        <div className="stat-card">
-          <Ticket className="w-6 h-6 text-indigo-600" />
-          <div className="text-2xl font-bold">{ticketStats.total}</div>
-          <div className="text-gray-600 text-sm">Total</div>
-        </div>
-        <div className="stat-card">
-          <Circle className="w-6 h-6 text-blue-600" />
-          <div className="text-2xl font-bold">{ticketStats.open}</div>
-          <div className="text-gray-600 text-sm">Open</div>
-        </div>
-        <div className="stat-card">
-          <CheckCircle2 className="w-6 h-6 text-green-600" />
-          <div className="text-2xl font-bold">{ticketStats.closed}</div>
-          <div className="text-gray-600 text-sm">Closed</div>
-        </div>
-        <div className="stat-card">
-          <AlertCircle className="w-6 h-6 text-yellow-600" />
-          <div className="text-2xl font-bold">{ticketStats.other}</div>
-          <div className="text-gray-600 text-sm">Other</div>
-        </div>
-      </div>
-
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100">
       {alert && <AnimatedAlert message={alert} type="success" onClose={() => setAlert(null)} />}
-
-      <div className="bg-white rounded-lg shadow p-4 space-y-2">
-        <h2 className="text-lg font-semibold flex items-center gap-2">
-          <Plus className="w-5 h-5" /> New Ticket
-        </h2>
-        <input
-          className="border w-full p-2 rounded"
-          placeholder="Title"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-        />
-        <textarea
-          className="border w-full p-2 rounded"
-          placeholder="Describe your issue"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-        />
-        <button className="bg-blue-600 text-white px-4 py-2 rounded" onClick={submit}>Submit</button>
+      <div className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-r from-blue-600 via-purple-600 to-indigo-700"></div>
+        <div className="absolute inset-0 bg-black/20"></div>
+        <div className="relative px-6 py-16 sm:py-24">
+          <div className="mx-auto max-w-7xl">
+            <div className="text-center">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6 }}
+                className="flex justify-center mb-6"
+              >
+                <div className="p-4 bg-white/10 backdrop-blur-sm rounded-2xl border border-white/20">
+                  <MessageCircle className="h-12 w-12 text-white" />
+                </div>
+              </motion.div>
+              <motion.h1
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.1 }}
+                className="text-4xl sm:text-5xl font-bold text-white mb-4"
+              >
+                Support
+              </motion.h1>
+              <motion.p
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.2 }}
+                className="text-xl text-blue-100 max-w-2xl mx-auto"
+              >
+                Create tickets and review your requests
+              </motion.p>
+            </div>
+          </div>
+        </div>
       </div>
 
-      <div className="bg-white rounded-lg shadow p-4">
-        <h2 className="text-lg font-semibold mb-2">My Tickets</h2>
-        <ul className="space-y-2">
-          {tickets.map((t) => (
-            <li
-              key={t.id}
-              className="glassy-card border rounded-lg p-3 shadow-sm space-y-1"
-            >
-              <div className="flex justify-between items-center">
-                <div className="font-medium text-gray-900 flex items-center gap-2">
-                  <button
-                    onClick={() =>
-                      setExpandedId(expandedId === t.id ? null : t.id)
-                    }
-                    className="text-gray-500 hover:text-gray-700"
-                  >
-                    <Eye className="h-4 w-4" />
-                  </button>
-                  {t.title}
+      <div className="relative -mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 space-y-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          {[
+            { icon: Ticket, label: 'Total', value: ticketStats.total, color: 'from-blue-500 to-blue-600' },
+            { icon: Circle, label: 'Open', value: ticketStats.open, color: 'from-indigo-500 to-indigo-600' },
+            { icon: CheckCircle2, label: 'Closed', value: ticketStats.closed, color: 'from-green-500 to-green-600' },
+            { icon: AlertCircle, label: 'Other', value: ticketStats.other, color: 'from-yellow-500 to-yellow-600' },
+          ].map((stat) => (
+            <div key={stat.label} className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-white/50">
+              <div className="flex items-center">
+                <div className={`p-3 rounded-xl bg-gradient-to-r ${stat.color} shadow-lg`}>
+                  <stat.icon className="h-6 w-6 text-white" />
                 </div>
-                <div className="flex items-center gap-2">
-                  <button
-                    onClick={() => startEdit(t)}
-                    className="p-1 text-blue-600 hover:text-blue-800"
-                  >
-                    <Edit2 className="h-4 w-4" />
-                  </button>
-                  <button
-                    onClick={() => remove(t.id)}
-                    className="p-1 text-red-600 hover:text-red-800"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </button>
+                <div className="ml-4">
+                  <p className="text-sm font-medium text-gray-600">{stat.label}</p>
+                  <p className="text-2xl font-bold text-gray-900">{stat.value}</p>
                 </div>
               </div>
-              <div className="text-sm text-gray-600">
-                {t.status} - {new Date(t.createdAt).toLocaleString()}
-              </div>
-              {(expandedId === t.id || editingId === t.id) && (
-                <div className="mt-2 space-y-2">
-                  {editingId === t.id ? (
-                    <>
-                      <input
-                        className="border rounded w-full p-1"
-                        value={editTitle}
-                        onChange={(e) => setEditTitle(e.target.value)}
-                      />
-                      <textarea
-                        className="border rounded w-full p-1"
-                        value={editDescription}
-                        onChange={(e) => setEditDescription(e.target.value)}
-                      />
-                      <select
-                        className="border rounded w-full p-1"
-                        value={editStatus}
-                        onChange={(e) => setEditStatus(e.target.value)}
-                      >
-                        <option value="open">Open</option>
-                        <option value="closed">Closed</option>
-                      </select>
-                      <div className="flex gap-2">
-                        <button
-                          onClick={saveEdit}
-                          className="px-3 py-1 bg-blue-600 text-white rounded"
-                        >
-                          Save
-                        </button>
-                        <button
-                          onClick={() => setEditingId(null)}
-                          className="px-3 py-1 bg-gray-200 rounded"
-                        >
-                          Cancel
-                        </button>
-                      </div>
-                    </>
-                  ) : (
-                    <p className="text-sm">{t.description}</p>
-                  )}
-                </div>
-              )}
-            </li>
+            </div>
           ))}
-          {tickets.length === 0 && <li>No tickets yet</li>}
-        </ul>
+        </div>
+
+        <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-white/50 space-y-4">
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <Plus className="w-5 h-5" /> New Ticket
+          </h2>
+          <input
+            className="border w-full p-2 rounded"
+            placeholder="Title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          <textarea
+            className="border w-full p-2 rounded"
+            placeholder="Describe your issue"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+          <button className="bg-blue-600 text-white px-4 py-2 rounded" onClick={submit}>Submit</button>
+        </div>
+
+        <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-4 shadow-lg border border-white/50">
+          <h2 className="text-lg font-semibold mb-2">My Tickets</h2>
+          <ul className="space-y-2">
+            {tickets.map((t) => (
+              <li
+                key={t.id}
+                className="border rounded-lg p-3 shadow-sm space-y-1 bg-white/70"
+              >
+                <div className="flex justify-between items-center">
+                  <div className="font-medium text-gray-900 flex items-center gap-2">
+                    <button
+                      onClick={() =>
+                        setExpandedId(expandedId === t.id ? null : t.id)
+                      }
+                      className="text-gray-500 hover:text-gray-700"
+                    >
+                      <Eye className="h-4 w-4" />
+                    </button>
+                    {t.title}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => startEdit(t)}
+                      className="p-1 text-blue-600 hover:text-blue-800"
+                    >
+                      <Edit2 className="h-4 w-4" />
+                    </button>
+                    <button
+                      onClick={() => remove(t.id)}
+                      className="p-1 text-red-600 hover:text-red-800"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
+                </div>
+                <div className="text-sm text-gray-600">
+                  {t.status} - {new Date(t.createdAt).toLocaleString()}
+                </div>
+                {(expandedId === t.id || editingId === t.id) && (
+                  <div className="mt-2 space-y-2">
+                    {editingId === t.id ? (
+                      <>
+                        <input
+                          className="border rounded w-full p-1"
+                          value={editTitle}
+                          onChange={(e) => setEditTitle(e.target.value)}
+                        />
+                        <textarea
+                          className="border rounded w-full p-1"
+                          value={editDescription}
+                          onChange={(e) => setEditDescription(e.target.value)}
+                        />
+                        <select
+                          className="border rounded w-full p-1"
+                          value={editStatus}
+                          onChange={(e) => setEditStatus(e.target.value)}
+                        >
+                          <option value="open">Open</option>
+                          <option value="closed">Closed</option>
+                        </select>
+                        <div className="flex gap-2">
+                          <button
+                            onClick={saveEdit}
+                            className="px-3 py-1 bg-blue-600 text-white rounded"
+                          >
+                            Save
+                          </button>
+                          <button
+                            onClick={() => setEditingId(null)}
+                            className="px-3 py-1 bg-gray-200 rounded"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </>
+                    ) : (
+                      <p className="text-sm">{t.description}</p>
+                    )}
+                  </div>
+                )}
+              </li>
+            ))}
+            {tickets.length === 0 && <li>No tickets yet</li>}
+          </ul>
+        </div>
       </div>
-      <style>{`
-        .glassy-card {
-          background: rgba(255,255,255,0.7);
-          backdrop-filter: blur(12px);
-        }
-        .stat-card {
-          background: white;
-          border-radius: 0.5rem;
-          box-shadow: 0 1px 2px rgba(0,0,0,0.1);
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          gap: 0.25rem;
-          padding: 1rem;
-          transition: transform 0.2s;
-        }
-        .stat-card:hover {
-          transform: translateY(-4px);
-        }
-      `}</style>
     </div>
   );
 }

--- a/src/components/pages/TrusteesPage.tsx
+++ b/src/components/pages/TrusteesPage.tsx
@@ -10,12 +10,8 @@ import {
   CheckCircle,
   Pencil,
   Plus,
-  Filter,
   Shield,
-  Clock,
-  Star,
-  Eye,
-  MoreVertical
+  Eye
 } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import {


### PR DESCRIPTION
## Summary
- restyle Support page with new hero and stat cards
- apply trustee/beneficiary style to Settings, API, Blockchain, and Collections pages
- clean up unused imports in Trustees page

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: '@typescript-eslint/no-unused-vars' in ReleasesPage)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6893ffe2f8a48321a97d46b04efdeb9f